### PR TITLE
[IIIF-325] Update Terraform Manifests to use AWS CloudFront

### DIFF
--- a/environments/prod/local.secrets.sample
+++ b/environments/prod/local.secrets.sample
@@ -13,6 +13,7 @@ dockerauth_arn                = "arn:aws:iam::0123456789:policy/auth_dockerhub"
 
 # General Cantaloupe Vars cantaloupe_processor_selection_strategy = "ManualSelectionStrategy"
 cantaloupe_app_port                     = "8182"
+cantaloupe_processor_selection_strategy = "ManualSelectionStrategy" 
 cantaloupe_manual_processor_jp2         = "KakaduNativeProcessor"
 cantaloupe_enable_admin                 = "true"
 cantaloupe_admin_secret                 = "testpassword"

--- a/environments/prod/local.secrets.sample
+++ b/environments/prod/local.secrets.sample
@@ -4,7 +4,8 @@ subnet_count        = 2
 subnet_int          = 10
 
 # IIIF URL setup
-iiif_app_name       = "example"
+iiif_app_name         = "example"
+iiif_app_ssl_cert_arn = "arn:aws:acm:us-west-2:0123456789:certificate/hash"
 
 # Ancillary vars needed for Fargate configuration to authenticate via Dockerhub
 dockerhubauth_credentials_arn = "arn:aws:secretsmanager:us-west-2:0123456789:secret:creds/ecs/secrets"
@@ -66,4 +67,13 @@ kakadu_converter_s3_tiff_bucket_region = "us-west-2"
 kakadu_converter_cloudwatch_permissions = ["logs:CreateLogGroup","logs:CreateLogStream","logs:PutLogEvents"]
 kakadu_converter_s3_permissions         = ["s3:*"]
 kakadu_converter_s3_buckets             = ["arn:aws:s3:::*","arn:aws:s3:::*"]
+
+# CloudFront Settings
+iiif_thumbnail_path_pattern                 = "*/full/*200*200/0/default.jpg"
+iiif_alb_dns_name                           = "ALBOriginURL"
+iiif_public_dns_names                       = ["yourpublicdomainname"]
+
+# This certificate arn needs be referenced from us-east-1. CloudFront only imports certificates from us-east-1 region
+iiif_cloudfront_ssl_certificate_arn         = "arn:aws:acm:us-east-1:0123456789:certificate/hash"
+iiif_cloudfront_price_class                 = "PriceClass_100"
 

--- a/environments/prod/main.tf
+++ b/environments/prod/main.tf
@@ -42,6 +42,7 @@ module "cantaloupe" {
   app_port                                = "${var.cantaloupe_app_port}"
   registry_url                            = "${var.cantaloupe_registry_url}"
   app_name                                = "${var.iiif_app_name}"
+  app_ssl_certificate_arn                 = "${var.iiif_app_ssl_cert_arn}"
   cantaloupe_cpu                          = "${var.cantaloupe_cpu}"
   cantaloupe_memory                       = "${var.cantaloupe_memory}"
   ecs_execution_role_arn                  = "${module.fargate_iam_policies.ecs_execution_role_arn}"
@@ -91,7 +92,7 @@ module "manifeststore" {
   manifeststore_s3_region          = "${var.manifeststore_s3_region}"
   ecs_execution_role_arn           = "${module.fargate_iam_policies.ecs_execution_role_arn}"
   dockerhubauth_credentials_arn    = "${var.dockerhubauth_credentials_arn}"
-  http_listener_arn                = "${module.cantaloupe.http_listener_arn}"
+  http_listener_arn                = "${module.cantaloupe.https_listener_arn}"
 
 ### Not available yet ###
 #  depends_on = [
@@ -131,5 +132,15 @@ module "kakadu_converter_lambda_tiff" {
   bucket_event = "${var.kakadu_converter_bucket_event}"
   trigger_s3_bucket_id = "${module.kakadu_converter_s3_tiff.bucket_id}"
   trigger_s3_bucket_arn = "${module.kakadu_converter_s3_tiff.bucket_arn}"
+}
+
+module "iiif_cloudfront" {
+  source                  = "git::https://github.com/UCLALibrary/aws_terraform_cloudfront_module.git?ref=IIIF-325"
+  app_origin_dns_name     = "${var.iiif_alb_dns_name}"
+  app_public_dns_names    = "${var.iiif_public_dns_names}"
+  app_origin_id           = "ALBOrigin-${var.iiif_alb_dns_name}"
+  app_ssl_certificate_arn = "${var.iiif_cloudfront_ssl_certificate_arn}"
+  app_path_pattern        = "${var.iiif_thumbnail_path_pattern}"
+  app_price_class         = "${var.iiif_cloudfront_price_class}"
 }
 

--- a/environments/prod/main.tf
+++ b/environments/prod/main.tf
@@ -135,7 +135,7 @@ module "kakadu_converter_lambda_tiff" {
 }
 
 module "iiif_cloudfront" {
-  source                  = "git::https://github.com/UCLALibrary/aws_terraform_cloudfront_module.git?ref=IIIF-325"
+  source                  = "git::https://github.com/UCLALibrary/aws_terraform_cloudfront_module.git"
   app_origin_dns_name     = "${var.iiif_alb_dns_name}"
   app_public_dns_names    = "${var.iiif_public_dns_names}"
   app_origin_id           = "ALBOrigin-${var.iiif_alb_dns_name}"

--- a/environments/prod/variables.tf
+++ b/environments/prod/variables.tf
@@ -57,6 +57,8 @@ variable "iiif_app_name" {
   default = "iiif"
 }
 
+variable "iiif_app_ssl_cert_arn" {}
+
 variable "cantaloupe_app_port" {
   default = 8182
 }
@@ -242,3 +244,8 @@ variable kakadu_converter_s3_permissions {}
 variable kakadu_converter_s3_buckets {}
 variable kakadu_converter_bucket_event {} 
 
+variable iiif_alb_dns_name {}
+variable iiif_public_dns_names {}
+variable iiif_thumbnail_path_pattern {}
+variable iiif_cloudfront_ssl_certificate_arn {}
+variable iiif_cloudfront_price_class {}

--- a/environments/test/local.secrets.sample
+++ b/environments/test/local.secrets.sample
@@ -4,7 +4,8 @@ subnet_count        = 2
 subnet_int          = 10
 
 # IIIF URL setup
-iiif_app_name       = "example"
+iiif_app_name         = "example"
+iiif_app_ssl_cert_arn = "arn:aws:acm:us-west-2:0123456789:certificate/hash"
 
 # Ancillary vars needed for Fargate configuration to authenticate via Dockerhub
 dockerhubauth_credentials_arn = "arn:aws:secretsmanager:us-west-2:0123456789:secret:creds/ecs/secrets"
@@ -12,6 +13,7 @@ dockerauth_arn                = "arn:aws:iam::0123456789:policy/auth_dockerhub"
 
 # General Cantaloupe Vars cantaloupe_processor_selection_strategy = "ManualSelectionStrategy"
 cantaloupe_app_port                     = "8182"
+cantaloupe_processor_selection_strategy = "ManualSelectionStrategy" 
 cantaloupe_manual_processor_jp2         = "KakaduNativeProcessor"
 cantaloupe_enable_admin                 = "true"
 cantaloupe_admin_secret                 = "testpassword"
@@ -66,4 +68,13 @@ kakadu_converter_s3_tiff_bucket_region = "us-west-2"
 kakadu_converter_cloudwatch_permissions = ["logs:CreateLogGroup","logs:CreateLogStream","logs:PutLogEvents"]
 kakadu_converter_s3_permissions         = ["s3:*"]
 kakadu_converter_s3_buckets             = ["arn:aws:s3:::*","arn:aws:s3:::*"]
+
+# CloudFront Settings
+iiif_thumbnail_path_pattern                 = "*/full/*200*200/0/default.jpg"
+iiif_alb_dns_name                           = "ALBOriginURL"
+iiif_public_dns_names                       = ["yourpublicdomainname"]
+
+# This certificate arn needs be referenced from us-east-1. CloudFront only imports certificates from us-east-1 region
+iiif_cloudfront_ssl_certificate_arn         = "arn:aws:acm:us-east-1:0123456789:certificate/hash"
+iiif_cloudfront_price_class                 = "PriceClass_100"
 

--- a/environments/test/main.tf
+++ b/environments/test/main.tf
@@ -42,6 +42,7 @@ module "cantaloupe" {
   app_port                                = "${var.cantaloupe_app_port}"
   registry_url                            = "${var.cantaloupe_registry_url}"
   app_name                                = "${var.iiif_app_name}"
+  app_ssl_certificate_arn                 = "${var.iiif_app_ssl_cert_arn}"
   cantaloupe_cpu                          = "${var.cantaloupe_cpu}"
   cantaloupe_memory                       = "${var.cantaloupe_memory}"
   ecs_execution_role_arn                  = "${module.fargate_iam_policies.ecs_execution_role_arn}"
@@ -91,7 +92,7 @@ module "manifeststore" {
   manifeststore_s3_region          = "${var.manifeststore_s3_region}"
   ecs_execution_role_arn           = "${module.fargate_iam_policies.ecs_execution_role_arn}"
   dockerhubauth_credentials_arn    = "${var.dockerhubauth_credentials_arn}"
-  http_listener_arn                = "${module.cantaloupe.http_listener_arn}"
+  http_listener_arn                = "${module.cantaloupe.https_listener_arn}"
 
 ### Not available yet ###
 #  depends_on = [
@@ -131,5 +132,15 @@ module "kakadu_converter_lambda_tiff" {
   bucket_event = "${var.kakadu_converter_bucket_event}"
   trigger_s3_bucket_id = "${module.kakadu_converter_s3_tiff.bucket_id}"
   trigger_s3_bucket_arn = "${module.kakadu_converter_s3_tiff.bucket_arn}"
+}
+
+module "iiif_cloudfront" {
+  source                  = "git::https://github.com/UCLALibrary/aws_terraform_cloudfront_module.git?ref=IIIF-325"
+  app_origin_dns_name     = "${var.iiif_alb_dns_name}"
+  app_public_dns_names    = "${var.iiif_public_dns_names}"
+  app_origin_id           = "ALBOrigin-${var.iiif_alb_dns_name}"
+  app_ssl_certificate_arn = "${var.iiif_cloudfront_ssl_certificate_arn}"
+  app_path_pattern        = "${var.iiif_thumbnail_path_pattern}"
+  app_price_class         = "${var.iiif_cloudfront_price_class}"
 }
 

--- a/environments/test/main.tf
+++ b/environments/test/main.tf
@@ -135,7 +135,7 @@ module "kakadu_converter_lambda_tiff" {
 }
 
 module "iiif_cloudfront" {
-  source                  = "git::https://github.com/UCLALibrary/aws_terraform_cloudfront_module.git?ref=IIIF-325"
+  source                  = "git::https://github.com/UCLALibrary/aws_terraform_cloudfront_module.git"
   app_origin_dns_name     = "${var.iiif_alb_dns_name}"
   app_public_dns_names    = "${var.iiif_public_dns_names}"
   app_origin_id           = "ALBOrigin-${var.iiif_alb_dns_name}"

--- a/environments/test/variables.tf
+++ b/environments/test/variables.tf
@@ -57,6 +57,8 @@ variable "iiif_app_name" {
   default = "iiif"
 }
 
+variable "iiif_app_ssl_cert_arn" {}
+
 variable "cantaloupe_app_port" {
   default = 8182
 }
@@ -242,3 +244,8 @@ variable kakadu_converter_s3_permissions {}
 variable kakadu_converter_s3_buckets {}
 variable kakadu_converter_bucket_event {} 
 
+variable iiif_alb_dns_name {}
+variable iiif_public_dns_names {}
+variable iiif_thumbnail_path_pattern {}
+variable iiif_cloudfront_ssl_certificate_arn {}
+variable iiif_cloudfront_price_class {}

--- a/modules/cantaloupe/main.tf
+++ b/modules/cantaloupe/main.tf
@@ -27,14 +27,32 @@ resource "aws_lb_target_group" "cantaloupe_tg" {
 }
 
 resource "aws_lb_listener" "cantaloupe_listener" {
-   load_balancer_arn = "${var.alb_main_id}"
-   port              = "80"
-   protocol          = "HTTP"
+  load_balancer_arn = "${var.alb_main_id}"
+  port              = "80"
+  protocol          = "HTTP"
 
-   default_action {
-     target_group_arn = "${aws_lb_target_group.cantaloupe_tg.arn}"
-     type             = "forward"
-   }
+  default_action {
+    type             = "redirect"
+
+    redirect {
+      port = "443"
+      protocol = "HTTPS"
+      status_code = "HTTP_301"    
+    }
+  }
+}
+
+resource "aws_lb_listener" "cantaloupe_listener_https" {
+  load_balancer_arn = "${var.alb_main_id}"
+  port              = "443"
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-2016-08"
+  certificate_arn   = "${var.app_ssl_certificate_arn}"
+
+  default_action {
+    target_group_arn = "${aws_lb_target_group.cantaloupe_tg.arn}"
+    type             = "forward"
+  }
 }
 
 resource "aws_ecs_cluster" "cantaloupe" {

--- a/modules/cantaloupe/outputs.tf
+++ b/modules/cantaloupe/outputs.tf
@@ -2,3 +2,7 @@ output "http_listener_arn" {
   value = "${aws_lb_listener.cantaloupe_listener.arn}"
 }
 
+output "https_listener_arn" {
+  value = "${aws_lb_listener.cantaloupe_listener_https.arn}"
+}
+

--- a/modules/cantaloupe/variables.tf
+++ b/modules/cantaloupe/variables.tf
@@ -6,6 +6,8 @@ variable "app_port" {
   default = 8182
 }
 
+variable app_ssl_certificate_arn {}
+
 variable "vpc_main_id" {
   default = null
 }


### PR DESCRIPTION
*Summary of changes*
* Configures and provisions iiif.library.ucla.edu and test-iiif.library.ucla.edu to be behind AWS CloudFront
* Make ALB listen and redirect to HTTPS for all incoming connections
* Update tfvars sample file
* This has already been tested and deployed into test/prod environments