### PR TITLE
[IIIF-401] Enable CF cache for all images

### DIFF
--- a/environments/prod/main.tf
+++ b/environments/prod/main.tf
@@ -140,7 +140,8 @@ module "iiif_cloudfront" {
   app_public_dns_names    = "${var.iiif_public_dns_names}"
   app_origin_id           = "ALBOrigin-${var.iiif_alb_dns_name}"
   app_ssl_certificate_arn = "${var.iiif_cloudfront_ssl_certificate_arn}"
-  app_path_pattern        = "${var.iiif_thumbnail_path_pattern}"
+  app_path_pattern        = "${var.iiif_jpg_path_pattern}"
   app_price_class         = "${var.iiif_cloudfront_price_class}"
+  default_ttl             = "${var.iiif_jpg_default_ttl}"
 }
 

--- a/environments/prod/variables.tf
+++ b/environments/prod/variables.tf
@@ -246,6 +246,7 @@ variable kakadu_converter_bucket_event {}
 
 variable iiif_alb_dns_name {}
 variable iiif_public_dns_names {}
-variable iiif_thumbnail_path_pattern {}
+variable iiif_jpg_path_pattern { default = "*.jpg" }
+variable iiif_jpg_default_ttl { default = 0 }
 variable iiif_cloudfront_ssl_certificate_arn {}
 variable iiif_cloudfront_price_class {}

--- a/environments/test/main.tf
+++ b/environments/test/main.tf
@@ -140,7 +140,8 @@ module "iiif_cloudfront" {
   app_public_dns_names    = "${var.iiif_public_dns_names}"
   app_origin_id           = "ALBOrigin-${var.iiif_alb_dns_name}"
   app_ssl_certificate_arn = "${var.iiif_cloudfront_ssl_certificate_arn}"
-  app_path_pattern        = "${var.iiif_thumbnail_path_pattern}"
+  app_path_pattern        = "${var.iiif_jpg_path_pattern}"
   app_price_class         = "${var.iiif_cloudfront_price_class}"
+  default_ttl             = "${var.iiif_jpg_default_ttl}"
 }
 

--- a/environments/test/variables.tf
+++ b/environments/test/variables.tf
@@ -246,6 +246,7 @@ variable kakadu_converter_bucket_event {}
 
 variable iiif_alb_dns_name {}
 variable iiif_public_dns_names {}
-variable iiif_thumbnail_path_pattern {}
+variable iiif_jpg_path_pattern { default = "*.jpg" }
+variable iiif_jpg_default_ttl { default = 0 }
 variable iiif_cloudfront_ssl_certificate_arn {}
 variable iiif_cloudfront_price_class {}


### PR DESCRIPTION
This is already tested and deployed on test-iiif and iiif.

```
avuong@POW-MD-DIT801:~ $ curl -I "https://test-iiif.library.ucla.edu/iiif/2/healthcheckimage/full/full/0/default.jpg"
HTTP/2 200
content-type: image/jpeg
date: Fri, 06 Sep 2019 20:02:33 GMT
x-powered-by: Cantaloupe/4.1.1
access-control-allow-origin: *
cache-control: max-age=2592000, public, no-transform
content-disposition: inline; filename=healthcheckimage.jpg
link: <https://test-iiif-alb.library.ucla.edu/iiif/2/healthcheckimage/full/full/0/default.jpg>;rel="canonical"
server: Jetty(9.4.z-SNAPSHOT)
vary: Accept-Encoding
x-cache: Hit from cloudfront
via: 1.1 76123233d5cffd2a25437cd32f2ca529.cloudfront.net (CloudFront)
x-amz-cf-pop: LAX3-C3
x-amz-cf-id: v_ZplTxk1Pi1bBgAtuF7ZnmzIo__mxQWya8C-ra0jPhd7TceEufWqA==
age: 10

avuong@POW-MD-DIT801:~ $ curl -I "https://iiif.library.ucla.edu/iiif/2/healthcheckimage/full/full/0/default.jpg"
HTTP/2 200
content-type: image/jpeg
date: Fri, 06 Sep 2019 19:34:53 GMT
x-powered-by: Cantaloupe/4.1.1
access-control-allow-origin: *
cache-control: max-age=2592000, public, no-transform
content-disposition: inline; filename=healthcheckimage.jpg
link: <https://iiif-alb.library.ucla.edu/iiif/2/healthcheckimage/full/full/0/default.jpg>;rel="canonical"
server: Jetty(9.4.z-SNAPSHOT)
vary: Accept-Encoding
x-cache: Hit from cloudfront
via: 1.1 85143b879454070b75f100e568f4bd0b.cloudfront.net (CloudFront)
x-amz-cf-pop: LAX3-C1
x-amz-cf-id: wxq3yBNRTur0uy2-kARXpjgNSBD_8uk7qi8jeq_T6JF1JwB2OTHlUA==
age: 1858
```