### PR TITLE
[IIIF-488] Migrate docker-cantaloupe codebuild from Labs to Services account

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 .terraform
-.sharecreds
 *.tfstate*
 *.secrets
 *plan.out*

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This repository contains terraform configuration files that is used to provision
 * Access to UCLA Library [Terraform Enterprise](https://app.terraform.io/session)
   * TFE User Token
 * Obtain local secrets file which is currently stored locally
+* TF Cloud for CodeBuild
 
 ### Steps to deploy
 * `cd environments/test-iiif`

--- a/environments/codebuild/README.md
+++ b/environments/codebuild/README.md
@@ -1,0 +1,9 @@
+# CHEATSHEET
+
+```
+alias tf='terraform'
+aws configure
+tf init
+tf plan -out currentplan -var-file=localsecrets.tfvars
+tf apply current plan
+```

--- a/environments/codebuild/README.md
+++ b/environments/codebuild/README.md
@@ -1,9 +1,0 @@
-# CHEATSHEET
-
-```
-alias tf='terraform'
-aws configure
-tf init
-tf plan -out currentplan -var-file=localsecrets.tfvars
-tf apply current plan
-```

--- a/environments/codebuild/main.tf
+++ b/environments/codebuild/main.tf
@@ -8,14 +8,14 @@ resource "aws_iam_role" "codebuild_role" {
 }
 
 resource "aws_iam_role_policy" "codebuild_policy_ssm_codebuild" {
-  role = "terraform-codebuild-shared-ssm-codebuild-policy"
+  role = "${aws_iam_role.codebuild_role.name}"
   policy = file("policies/ssm-codebuild-policy.json")
 }
 
-resource "aws_codebuild_project" "codebuild_project" {
-  name          = "${var.codebuild_project_name}"
-  description   = "${var.codebuild_project_description}"
-  build_timeout = "${var.codebuild_project_timeout_minutes}"
+resource "aws_codebuild_project" "docker-cantaloupe" {
+  name          = "docker-cantaloupe"
+  description   = "CodeBuild job for building docker-cantaloupe images"
+  build_timeout = "20"
   service_role  = "${aws_iam_role.codebuild_role.arn}"
   badge_enabled = true
 
@@ -43,10 +43,8 @@ resource "aws_codebuild_project" "codebuild_project" {
   }
 }
 
-resource "aws_ssm_parameter" "bucketeer_s3_access_key" {
-  name        = "AVTEST"
-  description = "AVTEST"
-  type        = "SecureString"
-  value       = "AVTEST"
+module "ssm_parameters" {
+  source   = "git::https://github.com/UCLALibrary/terraform-ssm-parameters.git?ref=1.0.0"
+  ssm_list = "${var.ssm_parameters_list}"
 }
 

--- a/environments/codebuild/main.tf
+++ b/environments/codebuild/main.tf
@@ -45,6 +45,6 @@ resource "aws_codebuild_project" "docker-cantaloupe" {
 
 module "ssm_parameters" {
   source   = "git::https://github.com/UCLALibrary/terraform-ssm-parameters.git?ref=1.0.0"
-  ssm_list = "${var.ssm_parameters_list}"
+  ssm_list = "${var.ssm_parameters_map}"
 }
 

--- a/environments/codebuild/main.tf
+++ b/environments/codebuild/main.tf
@@ -46,12 +46,6 @@ resource "aws_codebuild_project" "docker-cantaloupe" {
 module "ssm_parameters" {
   source  = "app.terraform.io/UCLALibrary/ssmparameters/aws"
   version = "1.0.0"
-  ssm_list = "${var.ssm_parameters_map}"
-}
-
-module "encrypted_ssm_parameters" {
-  source  = "app.terraform.io/UCLALibrary/ssmparameters/aws"
-  version = "1.0.0"
-  ssm_list = "${var.secure_ssm_parameters_map}"
+  ssm_list = "${local.ssm_parameters_merged}"
 }
 

--- a/environments/codebuild/main.tf
+++ b/environments/codebuild/main.tf
@@ -32,7 +32,7 @@ resource "aws_codebuild_project" "docker-cantaloupe" {
 
   source {
     type            = "GITHUB"
-    location        = "https://github.com/UCLALibrary/docker-jp2-bucketeer.git"
+    location        = "https://github.com/UCLALibrary/docker-cantaloupe.git"
     buildspec       = ".buildspec.yml"
   }
 

--- a/environments/codebuild/main.tf
+++ b/environments/codebuild/main.tf
@@ -43,8 +43,9 @@ resource "aws_codebuild_project" "docker-cantaloupe" {
   }
 }
 
-module "ssm_parameters" {
-  source   = "git::https://github.com/UCLALibrary/terraform-ssm-parameters.git?ref=1.0.0"
+module "ssmparameters" {
+  source  = "app.terraform.io/UCLALibrary/ssmparameters/aws"
+  version = "1.0.0"
   ssm_list = "${var.ssm_parameters_map}"
 }
 

--- a/environments/codebuild/main.tf
+++ b/environments/codebuild/main.tf
@@ -43,9 +43,15 @@ resource "aws_codebuild_project" "docker-cantaloupe" {
   }
 }
 
-module "ssmparameters" {
+module "ssm_parameters" {
   source  = "app.terraform.io/UCLALibrary/ssmparameters/aws"
   version = "1.0.0"
   ssm_list = "${var.ssm_parameters_map}"
+}
+
+module "encrypted_ssm_parameters" {
+  source  = "app.terraform.io/UCLALibrary/ssmparameters/aws"
+  version = "1.0.0"
+  ssm_list = "${var.secure_ssm_parameters_map}"
 }
 

--- a/environments/codebuild/main.tf
+++ b/environments/codebuild/main.tf
@@ -1,0 +1,52 @@
+provider "aws" {
+  region                  = "${var.region}"
+}
+
+resource "aws_iam_role" "codebuild_role" {
+  name = "terraform-codebuild-shared-role"
+  assume_role_policy = file("policies/codebuild-role-assume.json")
+}
+
+resource "aws_iam_role_policy" "codebuild_policy_ssm_codebuild" {
+  role = "terraform-codebuild-shared-ssm-codebuild-policy"
+  policy = file("policies/ssm-codebuild-policy.json")
+}
+
+resource "aws_codebuild_project" "codebuild_project" {
+  name          = "${var.codebuild_project_name}"
+  description   = "${var.codebuild_project_description}"
+  build_timeout = "${var.codebuild_project_timeout_minutes}"
+  service_role  = "${aws_iam_role.codebuild_role.arn}"
+  badge_enabled = true
+
+  artifacts {
+    type = "NO_ARTIFACTS"
+  }
+
+  environment {
+    compute_type                = "BUILD_GENERAL1_SMALL"
+    image                       = "${var.codebuild_project_image}"
+    type                        = "LINUX_CONTAINER"
+    privileged_mode             = true
+  }
+
+  source {
+    type            = "GITHUB"
+    location        = "https://github.com/UCLALibrary/docker-jp2-bucketeer.git"
+    buildspec       = ".buildspec.yml"
+  }
+
+  secondary_sources {
+    type               = "GITHUB"
+    source_identifier = "KAKADU"
+    location           = "https://github.com/UCLALibrary/kakadu.git"
+  }
+}
+
+resource "aws_ssm_parameter" "bucketeer_s3_access_key" {
+  name        = "AVTEST"
+  description = "AVTEST"
+  type        = "SecureString"
+  value       = "AVTEST"
+}
+

--- a/environments/codebuild/policies/codebuild-role-assume.json
+++ b/environments/codebuild/policies/codebuild-role-assume.json
@@ -1,0 +1,12 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "codebuild.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}

--- a/environments/codebuild/policies/ssm-codebuild-policy.json
+++ b/environments/codebuild/policies/ssm-codebuild-policy.json
@@ -1,0 +1,38 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Resource": [
+        "*"
+      ],
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ssm:Describe*",
+        "ssm:Get*",
+        "ssm:List*"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:CreateNetworkInterface",
+        "ec2:DescribeDhcpOptions",
+        "ec2:DescribeNetworkInterfaces",
+        "ec2:DeleteNetworkInterface",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeSecurityGroups",
+        "ec2:DescribeVpcs"
+      ],
+      "Resource": "*"
+    }
+  ]
+}

--- a/environments/codebuild/variables.tf
+++ b/environments/codebuild/variables.tf
@@ -7,7 +7,7 @@ variable "codebuild_project_image" {}
 variable "ssm_parameters_map" { type = map }
 variable "secure_ssm_parameters_map" { type = map }
 
-local {
+locals {
   ssm_parameters_merged = merge("${var.ssm_parameters_map}", "${var.secure_ssm_parameters_map}")
 }
 

--- a/environments/codebuild/variables.tf
+++ b/environments/codebuild/variables.tf
@@ -4,3 +4,5 @@ variable "codebuild_project_description" {}
 variable "codebuild_project_timeout_minutes" {}
 variable "codebuild_project_image" {}
 
+variable "ssm_parameters_map" { type = map }
+

--- a/environments/codebuild/variables.tf
+++ b/environments/codebuild/variables.tf
@@ -1,0 +1,6 @@
+variable "region" { default = "us-east-1" }
+variable "codebuild_project_name" {}
+variable "codebuild_project_description" {}
+variable "codebuild_project_timeout_minutes" {}
+variable "codebuild_project_image" {}
+

--- a/environments/codebuild/variables.tf
+++ b/environments/codebuild/variables.tf
@@ -7,3 +7,7 @@ variable "codebuild_project_image" {}
 variable "ssm_parameters_map" { type = map }
 variable "secure_ssm_parameters_map" { type = map }
 
+local {
+  ssm_parameters_merged = merge("${var.ssm_parameters_map}", "${var.secure_ssm_parameters_map}")
+}
+

--- a/environments/codebuild/variables.tf
+++ b/environments/codebuild/variables.tf
@@ -5,4 +5,5 @@ variable "codebuild_project_timeout_minutes" {}
 variable "codebuild_project_image" {}
 
 variable "ssm_parameters_map" { type = map }
+variable "secure_ssm_parameters_map" { type = map }
 


### PR DESCRIPTION
**Summary of Changes**
* This migration includes the following
  * Uses Terraform Cloud for deployment
  * State, vars, runs are stored in the services-aws-codebuild workspace
  * This is already deployed and tested
  * The current implementation also adds required SSM parameters for docker-cantaloupe via maps