### PR TITLE
[IIIF-479] Change healthcheck paths in AWS Load Balancers and update ping to status endpoint

### DIFF
--- a/environments/prod-iiif/main.tf
+++ b/environments/prod-iiif/main.tf
@@ -259,6 +259,20 @@ resource "aws_lb_listener_rule" "manifeststore_manifest" {
   }
 }
 
+resource "aws_lb_listener_rule" "manifeststore_healthcheck" {
+  listener_arn = "${aws_lb_listener.iiif_https_listener.arn}"
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.manifeststore_tg.arn}"
+  }
+
+  condition {
+    field  = "path-pattern"
+    values = ["/status/manifest-store"]
+  }
+}
+
 data "template_file" "fargate_iiif_definition" {
   template = "${file("templates/env_vars.properties.tpl")}"
   vars          = {

--- a/environments/prod-iiif/variables.tf
+++ b/environments/prod-iiif/variables.tf
@@ -52,14 +52,14 @@ variable "cantaloupe_s3_source_bucket" { default = "" }
 variable "cantaloupe_s3_source_basiclookup_suffix" { default = ".jpx" }
 variable "cantaloupe_source_static" { default = "S3Source" }
 variable "cantaloupe_heapsize" { default = "2g" }
-variable "cantaloupe_healthcheck_path" { default = "/" }
+variable "cantaloupe_healthcheck_path" { default = "/iiif/2" }
 
 # Manifeststore environment variables
 variable "manifeststore_memory" { default = "1024" }
 variable "manifeststore_cpu" { default = "1024" }
 variable "manifeststore_listening_port" { default = 8183 }
 variable "manifeststore_image_url" { default = "registry.hub.docker.com/uclalibrary/manifest-store:latest" }
-variable "manifeststore_healthcheck_path" { default = "/ping" }
+variable "manifeststore_healthcheck_path" { default = "/status/manifest-store" }
 variable "manifeststore_s3_bucket" { default = "" }
 variable "manifeststore_s3_access_key" { default = "" }
 variable "manifeststore_s3_secret_key" { default = "" }

--- a/environments/prod-sinai/main.tf
+++ b/environments/prod-sinai/main.tf
@@ -259,6 +259,20 @@ resource "aws_lb_listener_rule" "manifeststore_manifest" {
   }
 }
 
+resource "aws_lb_listener_rule" "manifeststore_healthcheck" {
+  listener_arn = "${aws_lb_listener.iiif_https_listener.arn}"
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.manifeststore_tg.arn}"
+  }
+
+  condition {
+    field  = "path-pattern"
+    values = ["/status/manifest-store"]
+  }
+}
+
 data "template_file" "fargate_iiif_definition" {
   template = "${file("templates/env_vars.properties.tpl")}"
   vars          = {

--- a/environments/prod-sinai/variables.tf
+++ b/environments/prod-sinai/variables.tf
@@ -52,14 +52,14 @@ variable "cantaloupe_s3_source_bucket" { default = "" }
 variable "cantaloupe_s3_source_basiclookup_suffix" { default = ".jpx" }
 variable "cantaloupe_source_static" { default = "S3Source" }
 variable "cantaloupe_heapsize" { default = "2g" }
-variable "cantaloupe_healthcheck_path" { default = "/" }
+variable "cantaloupe_healthcheck_path" { default = "/iiif/2" }
 
 # Manifeststore environment variables
 variable "manifeststore_memory" { default = "1024" }
 variable "manifeststore_cpu" { default = "1024" }
 variable "manifeststore_listening_port" { default = 8183 }
 variable "manifeststore_image_url" { default = "registry.hub.docker.com/uclalibrary/manifest-store:latest" }
-variable "manifeststore_healthcheck_path" { default = "/ping" }
+variable "manifeststore_healthcheck_path" { default = "/status/manifest-store" }
 variable "manifeststore_s3_bucket" { default = "" }
 variable "manifeststore_s3_access_key" { default = "" }
 variable "manifeststore_s3_secret_key" { default = "" }

--- a/environments/test-iiif/main.tf
+++ b/environments/test-iiif/main.tf
@@ -259,6 +259,20 @@ resource "aws_lb_listener_rule" "manifeststore_manifest" {
   }
 }
 
+resource "aws_lb_listener_rule" "manifeststore_healthcheck" {
+  listener_arn = "${aws_lb_listener.iiif_https_listener.arn}"
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.manifeststore_tg.arn}"
+  }
+
+  condition {
+    field  = "path-pattern"
+    values = ["/status/manifest-store"]
+  }
+}
+
 data "template_file" "fargate_iiif_definition" {
   template = "${file("templates/env_vars.properties.tpl")}"
   vars          = {

--- a/environments/test-iiif/variables.tf
+++ b/environments/test-iiif/variables.tf
@@ -52,14 +52,14 @@ variable "cantaloupe_s3_source_bucket" { default = "" }
 variable "cantaloupe_s3_source_basiclookup_suffix" { default = ".jpx" }
 variable "cantaloupe_source_static" { default = "S3Source" }
 variable "cantaloupe_heapsize" { default = "2g" }
-variable "cantaloupe_healthcheck_path" { default = "/" }
+variable "cantaloupe_healthcheck_path" { default = "/iiif/2" }
 
 # Manifeststore environment variables
 variable "manifeststore_memory" { default = "1024" }
 variable "manifeststore_cpu" { default = "1024" }
 variable "manifeststore_listening_port" { default = 8183 }
 variable "manifeststore_image_url" { default = "registry.hub.docker.com/uclalibrary/manifest-store:latest" }
-variable "manifeststore_healthcheck_path" { default = "/ping" }
+variable "manifeststore_healthcheck_path" { default = "/status/manifest-store" }
 variable "manifeststore_s3_bucket" { default = "" }
 variable "manifeststore_s3_access_key" { default = "" }
 variable "manifeststore_s3_secret_key" { default = "" }


### PR DESCRIPTION
**Summary of Changes**
* Changed healthcheck endpoint for cantaloupe from / to /iiif/2
* Changed healthcheck endpoint for fester from /ping to /status/manifest-store
* Add a listener rule that routes URIs matching /status/manifest-store to the fester container