### PR TITLE
[IIIF-533] Add S3Cache to be configured on Sinai Cantaloupe

### DIFF
--- a/environments/prod-sinai/main.tf
+++ b/environments/prod-sinai/main.tf
@@ -69,6 +69,14 @@ module "cantaloupe_src_bucket" {
   force_destroy_flag = "${var.force_destroy_src_bucket}"
 }
 
+### Create a cantaloupe cache bucket
+module "cantaloupe_cache_bucket" {
+  source             = "git::https://github.com/UCLALibrary/aws_terraform_s3_module.git"
+  bucket_name        = "${var.cantaloupe_s3_cache_bucket}"
+  bucket_region      = "${var.region}"
+  force_destroy_flag = "${var.force_destroy_cache_bucket}"
+}
+
 ### Create a manifeststore source bucket
 module "manifeststore_bucket" {
   source             = "git::https://github.com/UCLALibrary/aws_terraform_s3_module.git"
@@ -76,7 +84,6 @@ module "manifeststore_bucket" {
   bucket_region      = "${var.region}"
   force_destroy_flag = "${var.force_destroy_src_bucket}"
 }
-
 
 ### Create a security group that allows 80/443 access to the AWS Load Balancers
 resource "aws_security_group" "allow_alb_web" {

--- a/environments/prod-sinai/variables.tf
+++ b/environments/prod-sinai/variables.tf
@@ -18,6 +18,7 @@ variable "fargate_ecs_task_execution_role_arn" { default = "arn:aws:iam::aws:pol
 
 # Flag to destroy src buckets
 variable "force_destroy_src_bucket" { default = "false" }
+variable "force_destroy_cache_bucket" { default = "false" }
 
 # Fargate IIIF Settings
 variable "container_host_memory" { default = "2048" }


### PR DESCRIPTION
This has been deployed. I've confirmed that Sinai Cantaloupe is caching requests via S3Cache. The TTLs are set to keep the cached object around "forever" AKA, set to `0`.