### PR TITLE
[IIIF-576] Add resolve first flag to Terraform config for Sinai env

### DIFF
--- a/environments/prod-sinai/main.tf
+++ b/environments/prod-sinai/main.tf
@@ -295,6 +295,7 @@ data "template_file" "fargate_iiif_definition" {
     cantaloupe_cache_server_derivative      = "${var.cantaloupe_cache_server_derivative}"
     cantaloupe_cache_server_derivative_ttl  = "${var.cantaloupe_cache_server_derivative_ttl}"
     cantaloupe_cache_server_purge_missing   = "${var.cantaloupe_cache_server_purge_missing}"
+    cantaloupe_cache_server_resolve_first   = "${var.cantaloupe_cache_server_resolve_first}"
     cantaloupe_processor_selection_strategy = "${var.cantaloupe_processor_selection_strategy}"
     cantaloupe_manual_processor_jp2         = "${var.cantaloupe_manual_processor_jp2}"
     cantaloupe_s3_cache_access_key          = "${var.cantaloupe_s3_cache_access_key}"

--- a/environments/prod-sinai/templates/env_vars.properties.tpl
+++ b/environments/prod-sinai/templates/env_vars.properties.tpl
@@ -24,6 +24,7 @@
       { "name" : "CANTALOUPE_S3CACHE_SECRET_KEY", "value" : "${cantaloupe_s3_cache_secret_key}" },
       { "name" : "CANTALOUPE_S3CACHE_ENDPOINT", "value" : "${cantaloupe_s3_cache_endpoint}" },
       { "name" : "CANTALOUPE_S3CACHE_BUCKET_NAME", "value" : "${cantaloupe_s3_cache_bucket}" },
+      { "name" : "CANTALOUPE_CACHE_SERVER_RESOLVE_FIRST", "value" : "${cantaloupe_cache_server_resolve_first}" },
       { "name" : "CANTALOUPE_S3SOURCE_ACCESS_KEY_ID", "value" : "${cantaloupe_s3_source_access_key}" },
       { "name" : "CANTALOUPE_S3SOURCE_SECRET_KEY", "value" : "${cantaloupe_s3_source_secret_key}" },
       { "name" : "CANTALOUPE_S3SOURCE_ENDPOINT", "value" : "${cantaloupe_s3_source_endpoint}" },

--- a/environments/prod-sinai/variables.tf
+++ b/environments/prod-sinai/variables.tf
@@ -40,6 +40,7 @@ variable "cantaloupe_enable_cache_server" { default = "false" }
 variable "cantaloupe_cache_server_derivative" { default = "S3Cache" }
 variable "cantaloupe_cache_server_derivative_ttl" { default = "0" }
 variable "cantaloupe_cache_server_purge_missing" { default = "true" }
+variable "cantaloupe_cache_server_resolve_first" { default = "true" }
 variable "cantaloupe_processor_selection_strategy" { default = "ManualSelectionStrategy" }
 variable "cantaloupe_manual_processor_jp2" { default = "KakaduNativeProcessor" }
 variable "cantaloupe_s3_cache_access_key" { default = "something" }


### PR DESCRIPTION
Our Sinai Cantaloupe instance needs to set the resolve first flag to True to make each request(cache and non-cached) be processed by the delegate script.