### PR TITLE
[IIIF-583] Create stage-iiif environment

### DIFF
--- a/.travis/terraform-validate.sh
+++ b/.travis/terraform-validate.sh
@@ -5,7 +5,7 @@ TERRAFORM_URL="https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/ter
 TERRAFORM_BIN="${HOME}/terraform/bin"
 TERRAFORM="${TERRAFORM_BIN}/terraform"
 
-AWS_ENV=("test-iiif" "prod-iiif" "prod-network" "test-network" "prod-sinai")
+AWS_ENV=("test-iiif" "prod-iiif" "prod-network" "test-network" "prod-sinai" "stage-iiif")
 
 mkdir -p ${TERRAFORM_BIN}
 cd ${TERRAFORM_BIN}

--- a/environments/stage-iiif/bin/run
+++ b/environments/stage-iiif/bin/run
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Configured to use https://apps.terraform.io
+
+PLAN_FILE="plan.out"
+BACKEND_FILE="backend.hcl"
+LOCAL_SECRETS="local.secrets"
+TF_WORKSPACE="stage"
+
+if [[ ! -f ${BACKEND_FILE} ]];
+then
+  echo "${BACKEND_FILE} not found"
+  exit
+fi
+
+# This init makes sure that terraform is reading the latest backend.hcl configuration
+terraform init -input=false -backend-config=${BACKEND_FILE}
+
+if [[ -z $(terraform workspace list | grep -i ${TF_WORKSPACE}) ]];
+then
+  terraform workspace new ${TF_WORKSPACE}
+else
+  terraform workspace select ${TF_WORKSPACE}
+fi
+
+# This init ensures that the workspace created/selected has instantiated the necessary terraform providers
+terraform init
+
+echo "Working in workspace: $(terraform workspace show)"
+
+if [[ -f "${LOCAL_SECRETS}" ]];
+then
+  if [[ $1 == "destroy" ]];
+  then
+    terraform destroy -var-file="${LOCAL_SECRETS}"
+  else
+    terraform plan -out ${PLAN_FILE} -var-file="${LOCAL_SECRETS}" 
+  fi
+else
+  terraform plan -out ${PLAN_FILE}
+fi
+

--- a/environments/stage-iiif/local.secrets.sample
+++ b/environments/stage-iiif/local.secrets.sample
@@ -17,7 +17,7 @@ dockerhub_credentials_secrets_arn = "entersecretsarntoaccessprivatedockerregistr
 
 # Cantaloupe Container Definitions
 cantaloupe_memory                            = "4096"
-cantaloupe_image_url                         = "registry.hub.docker.com/uclalibrary/cantaloupe-ucla:4.1.4"
+cantaloupe_image_url                         = "registry.hub.docker.com/uclalibrary/cantaloupe:4.1.4"
 cantaloupe_listening_port                    = 8182
 cantaloupe_admin_secret                      = "enteradminpassword"
 cantaloupe_processor_selection_strategy      = "ManualSelectionStrategy"

--- a/environments/stage-iiif/local.secrets.sample
+++ b/environments/stage-iiif/local.secrets.sample
@@ -1,0 +1,51 @@
+# Terraform Configs
+terraform_remote_hostname             = "app.terraform.io"
+terraform_remote_token                = "ENTERTOKEN"
+terraform_remote_organization         = "ENTERORG"
+terraform_remote_networking_workspace = "ENTERVPCWORKSPACE"
+
+# IIIF URL setup
+iiif_app_name                 = "stage-app"
+iiif_app_ssl_cert_arn         = "enteracmarnforalb"
+
+# Fargate IIIF cluster settings
+container_host_memory             = "5120"
+container_host_cpu                = "2048"
+container_count                   = 2
+enable_load_balancer              = 1
+dockerhub_credentials_secrets_arn = "entersecretsarntoaccessprivatedockerregistry"
+
+# Cantaloupe Container Definitions
+cantaloupe_memory                            = "4096"
+cantaloupe_image_url                         = "registry.hub.docker.com/uclalibrary/cantaloupe-ucla:4.1.4"
+cantaloupe_listening_port                    = 8182
+cantaloupe_admin_secret                      = "enteradminpassword"
+cantaloupe_processor_selection_strategy      = "ManualSelectionStrategy"
+cantaloupe_manual_processor_jp2              = "KakaduNativeProcessor"
+cantaloupe_heapsize                          = "4g"
+cantaloupe_source_static                     = "S3Source"
+cantaloupe_s3_source_access_key              = "entersources3accesskey"
+cantaloupe_s3_source_secret_key              = "entersources3secretkey"
+cantaloupe_s3_source_bucket                  = "entersources3bucket"
+cantaloupe_s3_source_endpoint                = "s3.us-west-2.amazonaws.com"
+cantaloupe_s3_source_basiclookup_suffix      = ".jpx"
+
+# fester Container Definitions
+fester_memory                         = "1024"
+fester_listening_port                 = 8183
+fester_s3_access_key                  = "entersources3accesskey"
+fester_s3_secret_key                  = "entersources3secretkey"
+fester_s3_bucket                      = "entersources3bucket"
+fester_s3_region                      = "us-west-2"
+fester_image_tag                      = "0.0.1"
+
+# CloudFront Settigs
+iiif_jpg_path_pattern                       = "*.jpg"
+iiif_alb_dns_name                           = "enteralbdnsname"
+iiif_public_dns_names                       = ["enterpublicfacingdomain"]
+# This certificate arn needs be referenced from us-east-1. CloudFront only imports certificates from us-east-1 region
+iiif_cloudfront_ssl_certificate_arn         = "enteracmarnforcloudfront"
+iiif_cloudfront_price_class                 = "PriceClass_100"
+iiif_jpg_default_ttl                        = 0
+iiif_jpg_max_ttl                            = 31536000
+

--- a/environments/stage-iiif/main.tf
+++ b/environments/stage-iiif/main.tf
@@ -1,0 +1,353 @@
+terraform {
+  backend "remote" {}
+}
+
+provider "aws" {
+  profile = "${var.aws_profile}"
+  region  = "${var.region}"
+}
+
+### Configuration to retrieve VPC and subnets to provision to
+data "terraform_remote_state" "vpc" {
+  backend = "remote"
+  config = {
+    hostname = "${var.terraform_remote_hostname}"
+    token = "${var.terraform_remote_token}"
+    organization = "${var.terraform_remote_organization}"
+    workspaces = {
+      name = "${var.terraform_remote_networking_workspace}"
+    }
+  }
+}
+
+### Import IAM policy that grants the created ECS IAM role access to dockerhub credentials
+data "template_file" "ecs_iam_init" {
+  template      = "${file("policies/secrets-manager-dockerhub-auth.json.tpl")}"
+  vars          = {
+    secrets_arn = "${var.dockerhub_credentials_secrets_arn}"
+  }
+}
+
+### Create an IAM role that allows for ECS execution
+module "iiif_fargate_ecs_iam_role" {
+  source                     = "git::https://github.com/UCLALibrary/aws_terraform_module_iam_role.git"
+  iam_role_name              = "${local.fargate_ecs_role_name}"
+  iam_assume_policy_document = "${file("policies/assume-role-policy.json")}"
+}
+
+### Create IAM policy with template that grants secrets access
+resource "aws_iam_policy" "fargate_ecs_access_dockerhub_registry_policy" {
+  name   = "${local.fargate_ecs_role_name}-dockerhub-credentials-access"
+  policy = "${data.template_file.ecs_iam_init.rendered}"
+}
+
+### Create IAM policy that grants common ECS execution permissions
+resource "aws_iam_policy" "fargate_ecs_execution_policy" {
+  name   = "${local.fargate_ecs_role_name}-ecs-execution-policy"
+  policy = "${file("policies/ecs-execution-role-policy.json")}"
+}
+
+### Attach IAM policy to created role that grants ECS execution permissions
+resource "aws_iam_policy_attachment" "fargate_ecs_execution_role_policy_attachment" {
+  name       = "${local.fargate_ecs_role_name}-attach-ecs-execution-privs"
+  roles      = ["${module.iiif_fargate_ecs_iam_role.iam_role_name}"]
+  policy_arn = "${aws_iam_policy.fargate_ecs_execution_policy.arn}"
+}
+
+### Attach IAM policy that grants access to secrets manager from imported dockerhub template
+resource "aws_iam_policy_attachment" "fargate_credentials_secrets_privilege" {
+  name       = "${local.fargate_ecs_role_name}-attach-secrets-privs"
+  roles      = ["${module.iiif_fargate_ecs_iam_role.iam_role_name}"]
+  policy_arn = "${aws_iam_policy.fargate_ecs_access_dockerhub_registry_policy.arn}"
+}
+
+### Create a fester source bucket
+module "fester_bucket" {
+  source             = "git::https://github.com/UCLALibrary/aws_terraform_s3_module.git"
+  bucket_name        = "${var.fester_s3_bucket}"
+  bucket_region      = "${var.region}"
+  force_destroy_flag = "${var.force_destroy_src_bucket}"
+}
+
+
+### Create a security group that allows 80/443 access to the AWS Load Balancers
+resource "aws_security_group" "allow_alb_web" {
+  name          = "${var.iiif_app_name}-alb-allow-web"
+  description   = "Allow HTTP/HTTPS traffic to load balancers"
+  vpc_id        = data.terraform_remote_state.vpc.outputs.vpc_main_id
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port       = 0
+    to_port         = 0
+    protocol        = "-1"
+    cidr_blocks     = ["0.0.0.0/0"]
+  }
+}
+
+### Create a security group that allows the AWS Load Balancer to connect to the container ports
+resource "aws_security_group" "allow_alb_listening_port" {
+  name          = "${var.iiif_app_name}-alb-allow-listening-port"
+  description   = "Whitelist IIIF ALB to access application port on container"
+  vpc_id        = data.terraform_remote_state.vpc.outputs.vpc_main_id
+
+  ingress {
+    from_port       = "${var.cantaloupe_listening_port}"
+    to_port         = "${var.cantaloupe_listening_port}"
+    protocol        = "tcp"
+    security_groups = ["${aws_security_group.allow_alb_web.id}"]
+  }
+
+  ingress {
+    from_port       = "${var.fester_listening_port}"
+    to_port         = "${var.fester_listening_port}"
+    protocol        = "tcp"
+    security_groups = ["${aws_security_group.allow_alb_web.id}"]
+  }
+
+  egress {
+    from_port       = 0
+    to_port         = 0
+    protocol        = "-1"
+    cidr_blocks     = ["0.0.0.0/0"]
+  }
+}
+
+### Create an AWS Load Balancer
+module "alb" {
+  source         = "git::https://github.com/UCLALibrary/aws_terraform_module_alb.git"
+  alb_name       = "${var.iiif_app_name}-alb"
+
+  vpc_subnet_ids = data.terraform_remote_state.vpc.outputs.vpc_public_subnet_ids
+  alb_security_groups = ["${aws_security_group.allow_alb_web.id}"]
+}
+
+
+### Create a target group pointing to Cantaloupe on the IIIF cluster
+resource "aws_lb_target_group" "cantaloupe_tg" {
+  name        = "${var.iiif_app_name}-cantaloupe-tg"
+  protocol    = "HTTP"
+  vpc_id      = data.terraform_remote_state.vpc.outputs.vpc_main_id
+  target_type = "ip"
+  port        = "${var.cantaloupe_listening_port}"
+
+  health_check {
+    path = "${var.cantaloupe_healthcheck_path}"
+    port = "${var.cantaloupe_listening_port}"
+    healthy_threshold = 5
+    unhealthy_threshold = 2
+    timeout = 5
+    interval = 15
+    matcher = "200"
+  }
+}
+
+### Create a target group pointing to Fester on the IIIF cluster
+resource "aws_lb_target_group" "fester_tg" {
+  name        = "${var.iiif_app_name}-fester-tg"
+  protocol    = "HTTP"
+  vpc_id      = data.terraform_remote_state.vpc.outputs.vpc_main_id
+  target_type = "ip"
+  port        = "${var.fester_listening_port}"
+
+  health_check {
+    path = "${var.fester_healthcheck_path}"
+    port = "${var.fester_listening_port}"
+    healthy_threshold = 5
+    unhealthy_threshold = 2
+    timeout = 5
+    interval = 15
+    matcher = "200"
+  }
+}
+
+### Create a listener that redirects all HTTP traffic to HTTPS
+resource "aws_lb_listener" "iiif_http_listener" {
+  load_balancer_arn = "${module.alb.alb_main_id}"
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
+    type             = "redirect"
+
+    redirect {
+      port = "443"
+      protocol = "HTTPS"
+      status_code = "HTTP_301"    
+    }
+  }
+
+  depends_on = ["module.alb"]
+}
+
+### Create a listener to answer on HTTPS and set the default route to Cantaloupe's target group
+resource "aws_lb_listener" "iiif_https_listener" {
+  load_balancer_arn = "${module.alb.alb_main_id}"
+  port              = "443"
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-2016-08"
+  certificate_arn   = "${var.iiif_app_ssl_cert_arn}"
+
+  default_action {
+    target_group_arn = "${aws_lb_target_group.cantaloupe_tg.arn}"
+    type             = "forward"
+  }
+
+  depends_on = ["module.alb"]
+}
+
+resource "aws_lb_listener_rule" "fester_docs" {
+  listener_arn = "${aws_lb_listener.iiif_https_listener.arn}"
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.fester_tg.arn}"
+  }
+
+  condition {
+    path_pattern {
+      values = ["/docs/fester/*"]
+    }
+  }
+}
+
+resource "aws_lb_listener_rule" "fester_healthcheck" {
+  listener_arn = "${aws_lb_listener.iiif_https_listener.arn}"
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.fester_tg.arn}"
+  }
+
+  condition {
+    path_pattern {
+      values = ["/status/fester"]
+    }
+  }
+}
+
+resource "aws_lb_listener_rule" "fester_collections_root" {
+  listener_arn = "${aws_lb_listener.iiif_https_listener.arn}"
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.fester_tg.arn}"
+  }
+
+  condition {
+    path_pattern {
+      values = ["/collections"]
+    }
+  }
+}
+
+resource "aws_lb_listener_rule" "fester_collections_subpath" {
+  listener_arn = "${aws_lb_listener.iiif_https_listener.arn}"
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.fester_tg.arn}"
+  }
+
+  condition {
+    path_pattern {
+      values = ["/collections/*"]
+    }
+  }
+}
+
+resource "aws_lb_listener_rule" "fester_manifest" {
+  listener_arn = "${aws_lb_listener.iiif_https_listener.arn}"
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.fester_tg.arn}"
+  }
+
+  condition {
+    path_pattern {
+      values = ["/*/manifest"]
+    }
+  }
+}
+
+data "template_file" "fargate_iiif_definition" {
+  template = "${file("templates/env_vars.properties.tpl")}"
+  vars          = {
+    fargate_definition_name                 = "${local.fargate_definition_name}"
+    registry_auth_arn                       = "${var.dockerhub_credentials_secrets_arn}"
+    cantaloupe_memory                       = "${var.cantaloupe_memory}"
+    cantaloupe_cpu                          = "${var.cantaloupe_cpu}"
+    cantaloupe_image_url                    = "${var.cantaloupe_image_url}"
+    cantaloupe_listening_port               = "${var.cantaloupe_listening_port}"
+    cantaloupe_enable_admin                 = "${var.cantaloupe_enable_admin}"
+    cantaloupe_admin_secret                 = "${var.cantaloupe_admin_secret}"
+    cantaloupe_enable_cache_server          = "${var.cantaloupe_enable_cache_server}"
+    cantaloupe_cache_server_derivative      = "${var.cantaloupe_cache_server_derivative}"
+    cantaloupe_cache_server_derivative_ttl  = "${var.cantaloupe_cache_server_derivative_ttl}"
+    cantaloupe_cache_server_purge_missing   = "${var.cantaloupe_cache_server_purge_missing}"
+    cantaloupe_processor_selection_strategy = "${var.cantaloupe_processor_selection_strategy}"
+    cantaloupe_manual_processor_jp2         = "${var.cantaloupe_manual_processor_jp2}"
+    cantaloupe_s3_cache_access_key          = "${var.cantaloupe_s3_cache_access_key}"
+    cantaloupe_s3_cache_secret_key          = "${var.cantaloupe_s3_cache_secret_key}"
+    cantaloupe_s3_cache_endpoint            = "${var.cantaloupe_s3_cache_endpoint}"
+    cantaloupe_s3_cache_bucket              = "${var.cantaloupe_s3_cache_bucket}"
+    cantaloupe_s3_source_access_key         = "${var.cantaloupe_s3_source_access_key}"
+    cantaloupe_s3_source_secret_key         = "${var.cantaloupe_s3_source_secret_key}"
+    cantaloupe_s3_source_endpoint           = "${var.cantaloupe_s3_source_endpoint}"
+    cantaloupe_s3_source_bucket             = "${var.cantaloupe_s3_source_bucket != "" ? var.cantaloupe_s3_source_bucket : local.cantaloupe_s3_src_bucket}"
+    cantaloupe_s3_source_basiclookup_suffix = "${var.cantaloupe_s3_source_basiclookup_suffix}"
+    cantaloupe_source_static                = "${var.cantaloupe_source_static}"
+    cantaloupe_heapsize                     = "${var.cantaloupe_heapsize}"
+    fester_listening_port                   = "${var.fester_listening_port}"
+    fester_s3_access_key                    = "${var.fester_s3_access_key}"
+    fester_s3_secret_key                    = "${var.fester_s3_secret_key}"
+    fester_s3_region                        = "${var.fester_s3_region}"
+    fester_s3_bucket                        = "${var.fester_s3_bucket}"
+    fester_memory                           = "${var.fester_memory}"
+    fester_cpu                              = "${var.fester_cpu}"
+    fester_image_url                        = "${var.fester_image_url}"
+  }
+}
+
+module "iiif_fargate" {
+  source                  = "git::https://github.com/UCLALibrary/aws_terraform_module_fargate.git?ref=v0.2-beta"
+  memory                  = "${var.container_host_memory}"
+  cpu                     = "${var.container_host_cpu}"
+  execution_role_arn      = "${module.iiif_fargate_ecs_iam_role.iam_role_arn}"
+  registry_auth_arn       = "${var.dockerhub_credentials_secrets_arn}"
+  enable_load_balancer    = "${var.enable_load_balancer}"
+  fargate_cluster_name    = "${local.fargate_cluster_name}"
+  fargate_service_name    = "${local.fargate_service_name}"
+  fargate_definition_name = "${local.fargate_definition_name}"
+  sg_id                   = "${aws_security_group.allow_alb_listening_port.id}"
+  vpc_subnet_ids          = data.terraform_remote_state.vpc.outputs.vpc_public_subnet_ids
+  container_definitions   = "${data.template_file.fargate_iiif_definition.rendered}"
+  target_groups           = "${local.fargate_associate_tg}"
+}
+
+module "iiif_cloudfront" {
+  source                  = "git::https://github.com/UCLALibrary/aws_terraform_cloudfront_module.git"
+  app_origin_dns_name     = "${var.iiif_alb_dns_name}"
+  app_public_dns_names    = "${var.iiif_public_dns_names}"
+  app_origin_id           = "ALBOrigin-${var.iiif_alb_dns_name}"
+  app_ssl_certificate_arn = "${var.iiif_cloudfront_ssl_certificate_arn}"
+  app_path_pattern        = "${var.iiif_jpg_path_pattern}"
+  app_price_class         = "${var.iiif_cloudfront_price_class}"
+  default_ttl             = "${var.iiif_jpg_default_ttl}"
+  max_ttl                 = "${var.iiif_jpg_max_ttl}"
+}
+

--- a/environments/stage-iiif/main.tf
+++ b/environments/stage-iiif/main.tf
@@ -219,7 +219,7 @@ resource "aws_lb_listener_rule" "fester_docs" {
 
   condition {
     path_pattern {
-      values = ["/docs/fester/*"]
+      values = ["/docs/fester*"]
     }
   }
 }
@@ -319,7 +319,7 @@ data "template_file" "fargate_iiif_definition" {
     fester_s3_bucket                        = "${var.fester_s3_bucket}"
     fester_memory                           = "${var.fester_memory}"
     fester_cpu                              = "${var.fester_cpu}"
-    fester_image_url                        = "${var.fester_image_url}"
+    fester_image_url                        = "${local.fester_docker_image_url}"
   }
 }
 

--- a/environments/stage-iiif/main.tf
+++ b/environments/stage-iiif/main.tf
@@ -209,7 +209,7 @@ resource "aws_lb_listener" "iiif_https_listener" {
   depends_on = ["module.alb"]
 }
 
-resource "aws_lb_listener_rule" "fester_docs" {
+resource "aws_lb_listener_rule" "fester_docs_root" {
   listener_arn = "${aws_lb_listener.iiif_https_listener.arn}"
 
   action {
@@ -219,7 +219,22 @@ resource "aws_lb_listener_rule" "fester_docs" {
 
   condition {
     path_pattern {
-      values = ["/docs/fester*"]
+      values = ["/docs/fester"]
+    }
+  }
+}
+
+resource "aws_lb_listener_rule" "fester_docs_subpath" {
+  listener_arn = "${aws_lb_listener.iiif_https_listener.arn}"
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.fester_tg.arn}"
+  }
+
+  condition {
+    path_pattern {
+      values = ["/docs/fester/*"]
     }
   }
 }

--- a/environments/stage-iiif/policies/assume-role-policy.json
+++ b/environments/stage-iiif/policies/assume-role-policy.json
@@ -1,0 +1,12 @@
+{
+  "Version": "2008-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": ["ecs.amazonaws.com", "ecs-tasks.amazonaws.com", "ec2.amazonaws.com"]
+      },
+      "Effect": "Allow"
+    }
+  ]
+}

--- a/environments/stage-iiif/policies/ecs-execution-role-policy.json
+++ b/environments/stage-iiif/policies/ecs-execution-role-policy.json
@@ -1,0 +1,17 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ecr:GetAuthorizationToken",
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:GetDownloadUrlForLayer",
+                "ecr:BatchGetImage",
+                "logs:CreateLogStream",
+                "logs:PutLogEvents"
+            ],
+            "Resource": "*"
+        }
+    ]
+}

--- a/environments/stage-iiif/policies/ecs-role-policy.json
+++ b/environments/stage-iiif/policies/ecs-role-policy.json
@@ -1,0 +1,12 @@
+{
+  "Version": "2008-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": ["ecs.amazonaws.com", "ecs-tasks.amazonaws.com", "ec2.amazonaws.com"]
+      },
+      "Effect": "Allow"
+    }
+  ]
+}

--- a/environments/stage-iiif/policies/secrets-manager-dockerhub-auth.json.tpl
+++ b/environments/stage-iiif/policies/secrets-manager-dockerhub-auth.json.tpl
@@ -1,0 +1,11 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "VisualEditor0",
+            "Effect": "Allow",
+            "Action": "secretsmanager:GetSecretValue",
+            "Resource": "${secrets_arn}"
+        }
+    ]
+}

--- a/environments/stage-iiif/templates/env_vars.properties.tpl
+++ b/environments/stage-iiif/templates/env_vars.properties.tpl
@@ -46,7 +46,7 @@
       }
     ],
     "environment": [
-      { "name" : "HTTP_PORT", "value" : "${fester_listening_port}" },
+      { "name" : "FESTER_HTTP_PORT", "value" : "${fester_listening_port}" },
       { "name" : "FESTER_S3_ACCESS_KEY", "value" : "${fester_s3_access_key}" },
       { "name" : "FESTER_S3_BUCKET", "value" : "${fester_s3_bucket}" },
       { "name" : "FESTER_S3_REGION", "value" : "${fester_s3_region}" },

--- a/environments/stage-iiif/templates/env_vars.properties.tpl
+++ b/environments/stage-iiif/templates/env_vars.properties.tpl
@@ -1,0 +1,57 @@
+[
+  {
+    "name": "${fargate_definition_name}-cantaloupe",
+    "repositoryCredentials": { "credentialsParameter": "${registry_auth_arn}" },
+    "memory": ${cantaloupe_memory},
+    "image": "${cantaloupe_image_url}",
+    "networkMode": "awsvpc",
+    "portMappings": [
+      {
+        "containerPort": ${cantaloupe_listening_port},
+        "hostPort": ${cantaloupe_listening_port}
+      }
+    ],
+    "environment": [
+      { "name" : "CANTALOUPE_ENDPOINT_ADMIN_ENABLED", "value" : "${cantaloupe_enable_admin}" },
+      { "name" : "CANTALOUPE_ENDPOINT_ADMIN_SECRET", "value" :  "${cantaloupe_admin_secret}" },
+      { "name" : "CANTALOUPE_CACHE_SERVER_DERIVATIVE_ENABLED", "value" : "${cantaloupe_enable_cache_server}" },
+      { "name" : "CANTALOUPE_CACHE_SERVER_DERIVATIVE", "value" : "${cantaloupe_cache_server_derivative}" },
+      { "name" : "CANTALOUPE_CACHE_SERVER_DERIVATIVE_TTL_SECONDS", "value" : "${cantaloupe_cache_server_derivative_ttl}" },
+      { "name" : "CANTALOUPE_CACHE_SERVER_PURGE_MISSING", "value" : "${cantaloupe_cache_server_purge_missing}" },
+      { "name" : "CANTALOUPE_PROCESSOR_SELECTION_STRATEGY", "value" : "${cantaloupe_processor_selection_strategy}" },
+      { "name" : "CANTALOUPE_MANUAL_PROCESSOR_JP2", "value" : "${cantaloupe_manual_processor_jp2}" },
+      { "name" : "CANTALOUPE_S3CACHE_ACCESS_KEY_ID", "value" : "${cantaloupe_s3_cache_access_key}" },
+      { "name" : "CANTALOUPE_S3CACHE_SECRET_KEY", "value" : "${cantaloupe_s3_cache_secret_key}" },
+      { "name" : "CANTALOUPE_S3CACHE_ENDPOINT", "value" : "${cantaloupe_s3_cache_endpoint}" },
+      { "name" : "CANTALOUPE_S3CACHE_BUCKET_NAME", "value" : "${cantaloupe_s3_cache_bucket}" },
+      { "name" : "CANTALOUPE_S3SOURCE_ACCESS_KEY_ID", "value" : "${cantaloupe_s3_source_access_key}" },
+      { "name" : "CANTALOUPE_S3SOURCE_SECRET_KEY", "value" : "${cantaloupe_s3_source_secret_key}" },
+      { "name" : "CANTALOUPE_S3SOURCE_ENDPOINT", "value" : "${cantaloupe_s3_source_endpoint}" },
+      { "name" : "CANTALOUPE_S3SOURCE_BASICLOOKUPSTRATEGY_BUCKET_NAME", "value" : "${cantaloupe_s3_source_bucket}" },
+      { "name" : "CANTALOUPE_S3SOURCE_BASICLOOKUPSTRATEGY_PATH_SUFFIX", "value" : "${cantaloupe_s3_source_basiclookup_suffix}" },
+      { "name" : "CANTALOUPE_SOURCE_STATIC", "value" : "${cantaloupe_source_static}" },
+      { "name" : "JAVA_HEAP_SIZE", "value" : "${cantaloupe_heapsize}" }
+    ]
+  },
+  {
+    "name": "${fargate_definition_name}-fester",
+    "repositoryCredentials": { "credentialsParameter": "${registry_auth_arn}" },
+    "memory": ${fester_memory},
+    "image": "${fester_image_url}",
+    "networkMode": "awsvpc",
+    "portMappings": [
+      {
+        "containerPort": ${fester_listening_port},
+        "hostPort": ${fester_listening_port}
+      }
+    ],
+    "environment": [
+      { "name" : "HTTP_PORT", "value" : "${fester_listening_port}" },
+      { "name" : "FESTER_S3_ACCESS_KEY", "value" : "${fester_s3_access_key}" },
+      { "name" : "FESTER_S3_BUCKET", "value" : "${fester_s3_bucket}" },
+      { "name" : "FESTER_S3_REGION", "value" : "${fester_s3_region}" },
+      { "name" : "FESTER_S3_SECRET_KEY", "value" : "${fester_s3_secret_key}" }
+    ]
+  }
+]
+

--- a/environments/stage-iiif/variables.tf
+++ b/environments/stage-iiif/variables.tf
@@ -1,0 +1,99 @@
+# AWS Setup
+variable "region" { default = "us-west-2" }
+variable "aws_profile" { default = "default" }
+
+# Needed to reference remote state VPC networks
+variable "terraform_remote_hostname" {}
+variable "terraform_remote_token" {}
+variable "terraform_remote_organization" {}
+variable "terraform_remote_networking_workspace" {}
+
+### Name schemes and ARNS
+variable "iiif_app_name" {}
+variable "iiif_app_ssl_cert_arn" {}
+
+# Fargate ECS IAM Configurations(required)
+variable "dockerhub_credentials_secrets_arn" { default = "" }
+variable "fargate_ecs_task_execution_role_arn" { default = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy" }
+
+# Flag to destroy src buckets
+variable "force_destroy_src_bucket" { default = "false" }
+
+# Fargate IIIF Settings
+variable "container_host_memory" { default = "2048" }
+variable "container_host_cpu" { default = "1024" }
+variable "disable_load_balancer" { default = 0 }
+variable "enable_load_balancer" { default = 0 }
+variable "container_count" { default = 1 }
+variable "assign_public_ip" { default = true }
+variable "target_group_arn" { default = null }
+
+# Cantaloupe Environment Variables
+variable "cantaloupe_memory" { default = "2048" }
+variable "cantaloupe_cpu" { default = "1024" }
+variable "cantaloupe_listening_port" { default = 8182 }
+variable "cantaloupe_image_url" { default = "registry.hub.docker.com/uclalibrary/cantaloupe:4.1.3" }
+variable "cantaloupe_enable_admin" { default = "true" }
+variable "cantaloupe_admin_secret" { default = "secretpassword" }
+variable "cantaloupe_enable_cache_server" { default = "false" }
+variable "cantaloupe_cache_server_derivative" { default = "S3Cache" }
+variable "cantaloupe_cache_server_derivative_ttl" { default = "0" }
+variable "cantaloupe_cache_server_purge_missing" { default = "true" }
+variable "cantaloupe_processor_selection_strategy" { default = "ManualSelectionStrategy" }
+variable "cantaloupe_manual_processor_jp2" { default = "KakaduNativeProcessor" }
+variable "cantaloupe_s3_cache_access_key" { default = "something" }
+variable "cantaloupe_s3_cache_secret_key" { default = "something" }
+variable "cantaloupe_s3_cache_endpoint" { default = "us-west-2" }
+variable "cantaloupe_s3_cache_bucket" { default = "something" }
+variable "cantaloupe_s3_source_access_key" { default = "something" }
+variable "cantaloupe_s3_source_secret_key" { default = "something" }
+variable "cantaloupe_s3_source_endpoint" { default = "us-west-2" }
+variable "cantaloupe_s3_source_bucket" { default = "" }
+variable "cantaloupe_s3_source_basiclookup_suffix" { default = ".jpx" }
+variable "cantaloupe_source_static" { default = "S3Source" }
+variable "cantaloupe_heapsize" { default = "2g" }
+variable "cantaloupe_healthcheck_path" { default = "/iiif/2" }
+
+# Fester environment variables
+variable "fester_memory" { default = "1024" }
+variable "fester_cpu" { default = "1024" }
+variable "fester_listening_port" { default = 8183 }
+variable "fester_image_url" { default = "registry.hub.docker.com/uclalibrary/fester" }
+variable "fester_image_tag" { default = "latest" }
+variable "fester_healthcheck_path" { default = "/status/fester" }
+variable "fester_s3_bucket" { default = "" }
+variable "fester_s3_access_key" { default = "" }
+variable "fester_s3_secret_key" { default = "" }
+variable "fester_s3_region" { default = "" }
+
+# CloudFront Settings
+variable iiif_alb_dns_name {}
+variable iiif_public_dns_names {}
+variable iiif_jpg_path_pattern {}
+variable iiif_cloudfront_ssl_certificate_arn {}
+variable iiif_cloudfront_price_class {}
+variable iiif_jpg_default_ttl {}
+variable iiif_jpg_max_ttl {}
+
+locals {
+  fargate_ecs_role_name    = "${var.iiif_app_name}-fargate-ecs-role"
+  fargate_cluster_name     = "${var.iiif_app_name}-fargate-cluster"
+  fargate_service_name     = "${var.iiif_app_name}-fargate-service"
+  fargate_definition_name  = "${var.iiif_app_name}-fargate-definition"
+  fester_docker_image_url  = "${var.fester_image_url}:${var.fester_image_tag}"
+  cantaloupe_s3_src_bucket = "${var.iiif_app_name}-src-bucket"
+  sg_name                  = "${var.iiif_app_name}-security-group"
+  fargate_associate_tg     = [
+    {
+      arn = "${aws_lb_target_group.cantaloupe_tg.arn}"
+      container_name = "${local.fargate_definition_name}-cantaloupe"
+      container_port = "${var.cantaloupe_listening_port}"
+    },
+    {
+      arn = "${aws_lb_target_group.fester_tg.arn}"
+      container_name = "${local.fargate_definition_name}-fester"
+      container_port = "${var.fester_listening_port}"
+    }
+  ]
+}
+


### PR DESCRIPTION
*Summary of changes*
* A new stage-iiif terraform environment is created
* The stage environment reads from the prod-iiif cantaloupe source bucket. It does not have write access. So read only is enabled
* The stage environment has its own {{stage-iiif-fester-source}} bucket to store manifests
* This is currently deployed with {{fester:latest}} and we'll readjust the containers deployed after the other environments are fixed in subsequent PRs.