### PR TITLE
[IIIF-598] Update test environment to use new fester name scheme and latest tag

### DIFF
--- a/environments/test-iiif/main.tf
+++ b/environments/test-iiif/main.tf
@@ -69,10 +69,10 @@ module "cantaloupe_src_bucket" {
   force_destroy_flag = "${var.force_destroy_src_bucket}"
 }
 
-### Create a manifeststore source bucket
-module "manifeststore_bucket" {
+### Create a fester source bucket
+module "fester_bucket" {
   source             = "git::https://github.com/UCLALibrary/aws_terraform_s3_module.git"
-  bucket_name        = "${var.manifeststore_s3_bucket}"
+  bucket_name        = "${var.fester_s3_bucket}"
   bucket_region      = "${var.region}"
   force_destroy_flag = "${var.force_destroy_src_bucket}"
 }
@@ -120,8 +120,8 @@ resource "aws_security_group" "allow_alb_listening_port" {
   }
 
   ingress {
-    from_port       = "${var.manifeststore_listening_port}"
-    to_port         = "${var.manifeststore_listening_port}"
+    from_port       = "${var.fester_listening_port}"
+    to_port         = "${var.fester_listening_port}"
     protocol        = "tcp"
     security_groups = ["${aws_security_group.allow_alb_web.id}"]
   }
@@ -163,17 +163,17 @@ resource "aws_lb_target_group" "cantaloupe_tg" {
   }
 }
 
-### Create a target group pointing to Manifeststore on the IIIF cluster
-resource "aws_lb_target_group" "manifeststore_tg" {
-  name        = "${var.iiif_app_name}-manifeststore-tg"
+### Create a target group pointing to fester on the IIIF cluster
+resource "aws_lb_target_group" "fester_tg" {
+  name        = "${var.iiif_app_name}-fester-tg"
   protocol    = "HTTP"
   vpc_id      = data.terraform_remote_state.vpc.outputs.vpc_main_id
   target_type = "ip"
-  port        = "${var.manifeststore_listening_port}"
+  port        = "${var.fester_listening_port}"
 
   health_check {
-    path = "${var.manifeststore_healthcheck_path}"
-    port = "${var.manifeststore_listening_port}"
+    path = "${var.fester_healthcheck_path}"
+    port = "${var.fester_listening_port}"
     healthy_threshold = 5
     unhealthy_threshold = 2
     timeout = 5
@@ -217,31 +217,49 @@ resource "aws_lb_listener" "iiif_https_listener" {
   depends_on = ["module.alb"]
 }
 
-resource "aws_lb_listener_rule" "fester_docs" {
+resource "aws_lb_listener_rule" "fester_docs_root" {
   listener_arn = "${aws_lb_listener.iiif_https_listener.arn}"
 
   action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.manifeststore_tg.arn}"
+    target_group_arn = "${aws_lb_target_group.fester_tg.arn}"
   }
 
   condition {
-    field  = "path-pattern"
-    values = ["/docs/fester/*"]
+    path_pattern {
+      values = ["/docs/fester"]
+    }
   }
 }
+
+resource "aws_lb_listener_rule" "fester_docs_subpath" {
+  listener_arn = "${aws_lb_listener.iiif_https_listener.arn}"
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.fester_tg.arn}"
+  }
+
+  condition {
+    path_pattern {
+      values = ["/docs/fester/*"]
+    }
+  }
+}
+
 
 resource "aws_lb_listener_rule" "fester_healthcheck" {
   listener_arn = "${aws_lb_listener.iiif_https_listener.arn}"
 
   action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.manifeststore_tg.arn}"
+    target_group_arn = "${aws_lb_target_group.fester_tg.arn}"
   }
 
   condition {
-    field  = "path-pattern"
-    values = ["/status/fester"]
+    path_pattern {
+      values = ["/status/fester"]
+    }
   }
 }
 
@@ -250,26 +268,28 @@ resource "aws_lb_listener_rule" "fester_collections_root" {
 
   action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.manifeststore_tg.arn}"
+    target_group_arn = "${aws_lb_target_group.fester_tg.arn}"
   }
 
   condition {
-    field  = "path-pattern"
-    values = ["/collections"]
+    path_pattern {
+      values = ["/collections"]
+    }
   }
 }
 
-resource "aws_lb_listener_rule" "fester_collection_subpath" {
+resource "aws_lb_listener_rule" "fester_collections_subpath" {
   listener_arn = "${aws_lb_listener.iiif_https_listener.arn}"
 
   action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.manifeststore_tg.arn}"
+    target_group_arn = "${aws_lb_target_group.fester_tg.arn}"
   }
 
   condition {
-    field  = "path-pattern"
-    values = ["/collections/*"]
+    path_pattern {
+      values = ["/collections/*"]
+    }
   }
 }
 
@@ -278,12 +298,13 @@ resource "aws_lb_listener_rule" "fester_manifest" {
 
   action {
     type             = "forward"
-    target_group_arn = "${aws_lb_target_group.manifeststore_tg.arn}"
+    target_group_arn = "${aws_lb_target_group.fester_tg.arn}"
   }
 
   condition {
-    field  = "path-pattern"
-    values = ["/*/manifest"]
+    path_pattern {
+      values = ["/*/manifest"]
+    }
   }
 }
 
@@ -315,14 +336,14 @@ data "template_file" "fargate_iiif_definition" {
     cantaloupe_s3_source_basiclookup_suffix = "${var.cantaloupe_s3_source_basiclookup_suffix}"
     cantaloupe_source_static                = "${var.cantaloupe_source_static}"
     cantaloupe_heapsize                     = "${var.cantaloupe_heapsize}"
-    manifeststore_listening_port            = "${var.manifeststore_listening_port}"
-    manifeststore_s3_access_key             = "${var.manifeststore_s3_access_key}"
-    manifeststore_s3_secret_key             = "${var.manifeststore_s3_secret_key}"
-    manifeststore_s3_region                 = "${var.manifeststore_s3_region}"
-    manifeststore_s3_bucket                 = "${var.manifeststore_s3_bucket}"
-    manifeststore_memory                    = "${var.manifeststore_memory}"
-    manifeststore_cpu                       = "${var.manifeststore_cpu}"
-    manifeststore_image_url                 = "${var.manifeststore_image_url}"
+    fester_listening_port                   = "${var.fester_listening_port}"
+    fester_s3_access_key                    = "${var.fester_s3_access_key}"
+    fester_s3_secret_key                    = "${var.fester_s3_secret_key}"
+    fester_s3_region                        = "${var.fester_s3_region}"
+    fester_s3_bucket                        = "${var.fester_s3_bucket}"
+    fester_memory                           = "${var.fester_memory}"
+    fester_cpu                              = "${var.fester_cpu}"
+    fester_image_url                        = "${local.fester_docker_image_url}"
   }
 }
 

--- a/environments/test-iiif/templates/env_vars.properties.tpl
+++ b/environments/test-iiif/templates/env_vars.properties.tpl
@@ -34,23 +34,23 @@
     ]
   },
   {
-    "name": "${fargate_definition_name}-manifeststore",
+    "name": "${fargate_definition_name}-fester",
     "repositoryCredentials": { "credentialsParameter": "${registry_auth_arn}" },
-    "memory": ${manifeststore_memory},
-    "image": "${manifeststore_image_url}",
+    "memory": ${fester_memory},
+    "image": "${fester_image_url}",
     "networkMode": "awsvpc",
     "portMappings": [
       {
-        "containerPort": ${manifeststore_listening_port},
-        "hostPort": ${manifeststore_listening_port}
+        "containerPort": ${fester_listening_port},
+        "hostPort": ${fester_listening_port}
       }
     ],
     "environment": [
-      { "name" : "HTTP_PORT", "value" : "${manifeststore_listening_port}" },
-      { "name" : "MANIFESTSTORE_S3_ACCESS_KEY", "value" : "${manifeststore_s3_access_key}" },
-      { "name" : "MANIFESTSTORE_S3_BUCKET", "value" : "${manifeststore_s3_bucket}" },
-      { "name" : "MANIFESTSTORE_S3_REGION", "value" : "${manifeststore_s3_region}" },
-      { "name" : "MANIFESTSTORE_S3_SECRET_KEY", "value" : "${manifeststore_s3_secret_key}" }
+      { "name" : "FESTER_HTTP_PORT", "value" : "${fester_listening_port}" },
+      { "name" : "FESTER_S3_ACCESS_KEY", "value" : "${fester_s3_access_key}" },
+      { "name" : "FESTER_S3_BUCKET", "value" : "${fester_s3_bucket}" },
+      { "name" : "FESTER_S3_REGION", "value" : "${fester_s3_region}" },
+      { "name" : "FESTER_S3_SECRET_KEY", "value" : "${fester_s3_secret_key}" }
     ]
   }
 ]

--- a/environments/test-iiif/variables.tf
+++ b/environments/test-iiif/variables.tf
@@ -54,16 +54,17 @@ variable "cantaloupe_source_static" { default = "S3Source" }
 variable "cantaloupe_heapsize" { default = "2g" }
 variable "cantaloupe_healthcheck_path" { default = "/iiif/2" }
 
-# Manifeststore environment variables
-variable "manifeststore_memory" { default = "1024" }
-variable "manifeststore_cpu" { default = "1024" }
-variable "manifeststore_listening_port" { default = 8183 }
-variable "manifeststore_image_url" { default = "registry.hub.docker.com/uclalibrary/manifest-store:latest" }
-variable "manifeststore_healthcheck_path" { default = "/status/manifest-store" }
-variable "manifeststore_s3_bucket" { default = "" }
-variable "manifeststore_s3_access_key" { default = "" }
-variable "manifeststore_s3_secret_key" { default = "" }
-variable "manifeststore_s3_region" { default = "" }
+# fester environment variables
+variable "fester_memory" { default = "1024" }
+variable "fester_cpu" { default = "1024" }
+variable "fester_listening_port" { default = 8183 }
+variable "fester_image_url" { default = "registry.hub.docker.com/uclalibrary/fester" }
+variable "fester_image_tag" { default = "latest" }
+variable "fester_healthcheck_path" { default = "/status/fester" }
+variable "fester_s3_bucket" { default = "" }
+variable "fester_s3_access_key" { default = "" }
+variable "fester_s3_secret_key" { default = "" }
+variable "fester_s3_region" { default = "" }
 
 ## KakaduConverter Variables
 variable kakadu_converter_s3_tiff_bucket {}
@@ -102,6 +103,7 @@ locals {
   fargate_cluster_name     = "${var.iiif_app_name}-fargate-cluster"
   fargate_service_name     = "${var.iiif_app_name}-fargate-service"
   fargate_definition_name  = "${var.iiif_app_name}-fargate-definition"
+  fester_docker_image_url  = "${var.fester_image_url}:${var.fester_image_tag}"
   cantaloupe_s3_src_bucket = "${var.iiif_app_name}-src-bucket"
   sg_name                  = "${var.iiif_app_name}-security-group"
   fargate_associate_tg     = [
@@ -111,9 +113,9 @@ locals {
       container_port = "${var.cantaloupe_listening_port}"
     },
     {
-      arn = "${aws_lb_target_group.manifeststore_tg.arn}"
-      container_name = "${local.fargate_definition_name}-manifeststore"
-      container_port = "${var.manifeststore_listening_port}"
+      arn = "${aws_lb_target_group.fester_tg.arn}"
+      container_name = "${local.fargate_definition_name}-fester"
+      container_port = "${var.fester_listening_port}"
     }
   ]
 }


### PR DESCRIPTION
*Summary of changes*
* Renamed all the manifeststore components to Fester
* Created new buckets and sync'd bucket contents to newly created buckets
* Deleted old test Fester and Cantaloupe buckets
* Make Fargate deploy containers from {{fester:latest}}