### PR TITLE
[IIIF-630] [IIIF-514] [IIIF-605] Fargate/Cloudwatch/Rename adjustments

### DIFF
--- a/environments/prod-iiif/templates/env_vars.properties.tpl
+++ b/environments/prod-iiif/templates/env_vars.properties.tpl
@@ -5,6 +5,14 @@
     "memory": ${cantaloupe_memory},
     "image": "${cantaloupe_image_url}",
     "networkMode": "awsvpc",
+    "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+            "awslogs-group": "${cantaloupe_cloudwatch_log_group}",
+            "awslogs-region": "${cantaloupe_cloudwatch_region}",
+            "awslogs-stream-prefix": "${cantaloupe_cloudwatch_stream_prefix}"
+         }
+    },
     "portMappings": [
       {
         "containerPort": ${cantaloupe_listening_port},
@@ -34,23 +42,32 @@
     ]
   },
   {
-    "name": "${fargate_definition_name}-manifeststore",
+    "name": "${fargate_definition_name}-fester",
     "repositoryCredentials": { "credentialsParameter": "${registry_auth_arn}" },
-    "memory": ${manifeststore_memory},
-    "image": "${manifeststore_image_url}",
+    "memory": ${fester_memory},
+    "image": "${fester_image_url}",
     "networkMode": "awsvpc",
+    "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+            "awslogs-group": "${fester_cloudwatch_log_group}",
+            "awslogs-region": "${fester_cloudwatch_region}",
+            "awslogs-stream-prefix": "${fester_cloudwatch_stream_prefix}"
+         }
+    },
     "portMappings": [
       {
-        "containerPort": ${manifeststore_listening_port},
-        "hostPort": ${manifeststore_listening_port}
+        "containerPort": ${fester_listening_port},
+        "hostPort": ${fester_listening_port}
       }
     ],
     "environment": [
-      { "name" : "HTTP_PORT", "value" : "${manifeststore_listening_port}" },
-      { "name" : "MANIFESTSTORE_S3_ACCESS_KEY", "value" : "${manifeststore_s3_access_key}" },
-      { "name" : "MANIFESTSTORE_S3_BUCKET", "value" : "${manifeststore_s3_bucket}" },
-      { "name" : "MANIFESTSTORE_S3_REGION", "value" : "${manifeststore_s3_region}" },
-      { "name" : "MANIFESTSTORE_S3_SECRET_KEY", "value" : "${manifeststore_s3_secret_key}" }
+      { "name" : "FESTER_HTTP_PORT", "value" : "${fester_listening_port}" },
+      { "name" : "FESTER_S3_ACCESS_KEY", "value" : "${fester_s3_access_key}" },
+      { "name" : "FESTER_S3_BUCKET", "value" : "${fester_s3_bucket}" },
+      { "name" : "FESTER_S3_REGION", "value" : "${fester_s3_region}" },
+      { "name" : "FESTER_S3_SECRET_KEY", "value" : "${fester_s3_secret_key}" },
+      { "name" : "IIIF_BASE_URL", "value" : "${fester_iiif_base_url}" }
     ]
   }
 ]

--- a/environments/prod-sinai/main.tf
+++ b/environments/prod-sinai/main.tf
@@ -225,6 +225,9 @@ data "template_file" "fargate_iiif_definition" {
     delegate_url                            = "${var.delegate_url}"
     cipher_text                             = "${var.cipher_text}"
     cipher_key                              = "${var.cipher_key}"
+    cantaloupe_cloudwatch_log_group         = "${var.cantaloupe_cloudwatch_log_group}"
+    cantaloupe_cloudwatch_region            = "${var.cantaloupe_cloudwatch_region}"
+    cantaloupe_cloudwatch_stream_prefix     = "${var.cantaloupe_cloudwatch_stream_prefix}"
   }
 }
 

--- a/environments/prod-sinai/templates/env_vars.properties.tpl
+++ b/environments/prod-sinai/templates/env_vars.properties.tpl
@@ -5,6 +5,14 @@
     "memory": ${cantaloupe_memory},
     "image": "${cantaloupe_image_url}",
     "networkMode": "awsvpc",
+    "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+            "awslogs-group": "${cantaloupe_cloudwatch_log_group}",
+            "awslogs-region": "${cantaloupe_cloudwatch_region}",
+            "awslogs-stream-prefix": "${cantaloupe_cloudwatch_stream_prefix}"
+         }
+    },
     "portMappings": [
       {
         "containerPort": ${cantaloupe_listening_port},

--- a/environments/prod-sinai/templates/env_vars.properties.tpl
+++ b/environments/prod-sinai/templates/env_vars.properties.tpl
@@ -39,26 +39,6 @@
       { "name" : "CIPHER_KEY", "value" : "${cipher_key}" },
       { "name" : "JAVA_HEAP_SIZE", "value" : "${cantaloupe_heapsize}" }
     ]
-  },
-  {
-    "name": "${fargate_definition_name}-manifeststore",
-    "repositoryCredentials": { "credentialsParameter": "${registry_auth_arn}" },
-    "memory": ${manifeststore_memory},
-    "image": "${manifeststore_image_url}",
-    "networkMode": "awsvpc",
-    "portMappings": [
-      {
-        "containerPort": ${manifeststore_listening_port},
-        "hostPort": ${manifeststore_listening_port}
-      }
-    ],
-    "environment": [
-      { "name" : "HTTP_PORT", "value" : "${manifeststore_listening_port}" },
-      { "name" : "MANIFESTSTORE_S3_ACCESS_KEY", "value" : "${manifeststore_s3_access_key}" },
-      { "name" : "MANIFESTSTORE_S3_BUCKET", "value" : "${manifeststore_s3_bucket}" },
-      { "name" : "MANIFESTSTORE_S3_REGION", "value" : "${manifeststore_s3_region}" },
-      { "name" : "MANIFESTSTORE_S3_SECRET_KEY", "value" : "${manifeststore_s3_secret_key}" }
-    ]
   }
 ]
 

--- a/environments/prod-sinai/variables.tf
+++ b/environments/prod-sinai/variables.tf
@@ -61,6 +61,9 @@ variable "cantaloupe_source_delegate" { default = "true" }
 variable "delegate_url" { default = "https://raw.githubusercontent.com/UCLALibrary/cantaloupe-delegate/master/lib/delegates.rb" }
 variable "cipher_text" { default = "text" }
 variable "cipher_key" { default = "key" }
+variable "cantaloupe_cloudwatch_log_group" { default = "/ecs/prod-sinai-iiif" }
+variable "cantaloupe_cloudwatch_region" { default = "us-west-2" }
+variable "cantaloupe_cloudwatch_stream_prefix" { default = "cantaloupe_" }
 
 ## KakaduConverter Variables
 variable kakadu_converter_s3_tiff_bucket {}

--- a/environments/prod-sinai/variables.tf
+++ b/environments/prod-sinai/variables.tf
@@ -62,17 +62,6 @@ variable "delegate_url" { default = "https://raw.githubusercontent.com/UCLALibra
 variable "cipher_text" { default = "text" }
 variable "cipher_key" { default = "key" }
 
-# Manifeststore environment variables
-variable "manifeststore_memory" { default = "1024" }
-variable "manifeststore_cpu" { default = "1024" }
-variable "manifeststore_listening_port" { default = 8183 }
-variable "manifeststore_image_url" { default = "registry.hub.docker.com/uclalibrary/manifest-store:latest" }
-variable "manifeststore_healthcheck_path" { default = "/status/manifest-store" }
-variable "manifeststore_s3_bucket" { default = "" }
-variable "manifeststore_s3_access_key" { default = "" }
-variable "manifeststore_s3_secret_key" { default = "" }
-variable "manifeststore_s3_region" { default = "" }
-
 ## KakaduConverter Variables
 variable kakadu_converter_s3_tiff_bucket {}
 variable kakadu_converter_s3_tiff_bucket_region { default = "us-west-2"}
@@ -137,11 +126,6 @@ locals {
       arn = "${aws_lb_target_group.cantaloupe_tg.arn}"
       container_name = "${local.fargate_definition_name}-cantaloupe"
       container_port = "${var.cantaloupe_listening_port}"
-    },
-    {
-      arn = "${aws_lb_target_group.manifeststore_tg.arn}"
-      container_name = "${local.fargate_definition_name}-manifeststore"
-      container_port = "${var.manifeststore_listening_port}"
     }
   ]
 }

--- a/environments/stage-iiif/bin/run
+++ b/environments/stage-iiif/bin/run
@@ -33,7 +33,7 @@ then
   then
     terraform destroy -var-file="${LOCAL_SECRETS}"
   else
-    terraform plan -out ${PLAN_FILE} -var-file="${LOCAL_SECRETS}" 
+    terraform plan -out ${PLAN_FILE} -var-file="${LOCAL_SECRETS}"
   fi
 else
   terraform plan -out ${PLAN_FILE}

--- a/environments/stage-iiif/templates/env_vars.properties.tpl
+++ b/environments/stage-iiif/templates/env_vars.properties.tpl
@@ -5,6 +5,14 @@
     "memory": ${cantaloupe_memory},
     "image": "${cantaloupe_image_url}",
     "networkMode": "awsvpc",
+    "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+            "awslogs-group": "${cantaloupe_cloudwatch_log_group}",
+            "awslogs-region": "${cantaloupe_cloudwatch_region}",
+            "awslogs-stream-prefix": "${cantaloupe_cloudwatch_stream_prefix}"
+         }
+    },
     "portMappings": [
       {
         "containerPort": ${cantaloupe_listening_port},
@@ -39,6 +47,14 @@
     "memory": ${fester_memory},
     "image": "${fester_image_url}",
     "networkMode": "awsvpc",
+    "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+            "awslogs-group": "${fester_cloudwatch_log_group}",
+            "awslogs-region": "${fester_cloudwatch_region}",
+            "awslogs-stream-prefix": "${fester_cloudwatch_stream_prefix}"
+         }
+    },
     "portMappings": [
       {
         "containerPort": ${fester_listening_port},
@@ -50,7 +66,8 @@
       { "name" : "FESTER_S3_ACCESS_KEY", "value" : "${fester_s3_access_key}" },
       { "name" : "FESTER_S3_BUCKET", "value" : "${fester_s3_bucket}" },
       { "name" : "FESTER_S3_REGION", "value" : "${fester_s3_region}" },
-      { "name" : "FESTER_S3_SECRET_KEY", "value" : "${fester_s3_secret_key}" }
+      { "name" : "FESTER_S3_SECRET_KEY", "value" : "${fester_s3_secret_key}" },
+      { "name" : "IIIF_BASE_URL", "value" : "${fester_iiif_base_url}" }
     ]
   }
 ]

--- a/environments/stage-iiif/variables.tf
+++ b/environments/stage-iiif/variables.tf
@@ -2,6 +2,9 @@
 variable "region" { default = "us-west-2" }
 variable "aws_profile" { default = "default" }
 
+# Load Balancer Settings
+variable "lb_idle_timeout" { default = "300" }
+
 # Needed to reference remote state VPC networks
 variable "terraform_remote_hostname" {}
 variable "terraform_remote_token" {}
@@ -18,6 +21,7 @@ variable "fargate_ecs_task_execution_role_arn" { default = "arn:aws:iam::aws:pol
 
 # Flag to destroy src buckets
 variable "force_destroy_src_bucket" { default = "false" }
+variable "force_destroy_cache_bucket" { default = "false" }
 
 # Fargate IIIF Settings
 variable "container_host_memory" { default = "2048" }
@@ -53,6 +57,9 @@ variable "cantaloupe_s3_source_basiclookup_suffix" { default = ".jpx" }
 variable "cantaloupe_source_static" { default = "S3Source" }
 variable "cantaloupe_heapsize" { default = "2g" }
 variable "cantaloupe_healthcheck_path" { default = "/iiif/2" }
+variable "cantaloupe_cloudwatch_log_group" { default = "/ecs/stage-iiif" }
+variable "cantaloupe_cloudwatch_region" { default = "us-west-2" }
+variable "cantaloupe_cloudwatch_stream_prefix" { default = "cantaloupe_" }
 
 # Fester environment variables
 variable "fester_memory" { default = "1024" }
@@ -65,6 +72,10 @@ variable "fester_s3_bucket" { default = "" }
 variable "fester_s3_access_key" { default = "" }
 variable "fester_s3_secret_key" { default = "" }
 variable "fester_s3_region" { default = "" }
+variable "fester_iiif_base_url" { default = "https://stage-iiif.library.ucla.edu/iiif/2" }                                                                                                               
+variable "fester_cloudwatch_log_group" { default = "/ecs/stage-iiif" }
+variable "fester_cloudwatch_region" { default = "us-west-2" }
+variable "fester_cloudwatch_stream_prefix" { default = "fester_" }
 
 # CloudFront Settings
 variable iiif_alb_dns_name {}

--- a/environments/test-iiif/main.tf
+++ b/environments/test-iiif/main.tf
@@ -69,6 +69,15 @@ module "cantaloupe_src_bucket" {
   force_destroy_flag = "${var.force_destroy_src_bucket}"
 }
 
+### Create a cantaloupe cache bucket
+module "cantaloupe_cache_bucket" {
+  source             = "git::https://github.com/UCLALibrary/aws_terraform_s3_module.git"
+  bucket_name        = "${var.cantaloupe_s3_cache_bucket}"
+  bucket_region      = "${var.region}"
+  force_destroy_flag = "${var.force_destroy_cache_bucket}"
+}
+
+
 ### Create a fester source bucket
 module "fester_bucket" {
   source             = "git::https://github.com/UCLALibrary/aws_terraform_s3_module.git"
@@ -141,6 +150,7 @@ module "alb" {
 
   vpc_subnet_ids = data.terraform_remote_state.vpc.outputs.vpc_public_subnet_ids
   alb_security_groups = ["${aws_security_group.allow_alb_web.id}"]
+  idle_timeout = "${var.lb_idle_timeout}"
 }
 
 
@@ -157,7 +167,7 @@ resource "aws_lb_target_group" "cantaloupe_tg" {
     port = "${var.cantaloupe_listening_port}"
     healthy_threshold = 5
     unhealthy_threshold = 2
-    timeout = 5
+    timeout =  10
     interval = 15
     matcher = "200"
   }
@@ -176,7 +186,7 @@ resource "aws_lb_target_group" "fester_tg" {
     port = "${var.fester_listening_port}"
     healthy_threshold = 5
     unhealthy_threshold = 2
-    timeout = 5
+    timeout = 10
     interval = 15
     matcher = "200"
   }
@@ -336,6 +346,9 @@ data "template_file" "fargate_iiif_definition" {
     cantaloupe_s3_source_basiclookup_suffix = "${var.cantaloupe_s3_source_basiclookup_suffix}"
     cantaloupe_source_static                = "${var.cantaloupe_source_static}"
     cantaloupe_heapsize                     = "${var.cantaloupe_heapsize}"
+    cantaloupe_cloudwatch_log_group         = "${var.cantaloupe_cloudwatch_log_group}"
+    cantaloupe_cloudwatch_region            = "${var.cantaloupe_cloudwatch_region}"
+    cantaloupe_cloudwatch_stream_prefix     = "${var.cantaloupe_cloudwatch_stream_prefix}"
     fester_listening_port                   = "${var.fester_listening_port}"
     fester_s3_access_key                    = "${var.fester_s3_access_key}"
     fester_s3_secret_key                    = "${var.fester_s3_secret_key}"
@@ -344,6 +357,10 @@ data "template_file" "fargate_iiif_definition" {
     fester_memory                           = "${var.fester_memory}"
     fester_cpu                              = "${var.fester_cpu}"
     fester_image_url                        = "${local.fester_docker_image_url}"
+    fester_iiif_base_url                    = "${var.fester_iiif_base_url}"
+    fester_cloudwatch_log_group             = "${var.fester_cloudwatch_log_group}"
+    fester_cloudwatch_region                = "${var.fester_cloudwatch_region}"
+    fester_cloudwatch_stream_prefix         = "${var.fester_cloudwatch_stream_prefix}"
   }
 }
 

--- a/environments/test-iiif/templates/env_vars.properties.tpl
+++ b/environments/test-iiif/templates/env_vars.properties.tpl
@@ -5,6 +5,14 @@
     "memory": ${cantaloupe_memory},
     "image": "${cantaloupe_image_url}",
     "networkMode": "awsvpc",
+    "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+            "awslogs-group": "${cantaloupe_cloudwatch_log_group}",
+            "awslogs-region": "${cantaloupe_cloudwatch_region}",
+            "awslogs-stream-prefix": "${cantaloupe_cloudwatch_stream_prefix}"
+         }
+    },
     "portMappings": [
       {
         "containerPort": ${cantaloupe_listening_port},
@@ -39,6 +47,14 @@
     "memory": ${fester_memory},
     "image": "${fester_image_url}",
     "networkMode": "awsvpc",
+    "logConfiguration": {
+        "logDriver": "awslogs",
+        "options": {
+            "awslogs-group": "${fester_cloudwatch_log_group}",
+            "awslogs-region": "${fester_cloudwatch_region}",
+            "awslogs-stream-prefix": "${fester_cloudwatch_stream_prefix}"
+         }
+    },
     "portMappings": [
       {
         "containerPort": ${fester_listening_port},
@@ -50,7 +66,8 @@
       { "name" : "FESTER_S3_ACCESS_KEY", "value" : "${fester_s3_access_key}" },
       { "name" : "FESTER_S3_BUCKET", "value" : "${fester_s3_bucket}" },
       { "name" : "FESTER_S3_REGION", "value" : "${fester_s3_region}" },
-      { "name" : "FESTER_S3_SECRET_KEY", "value" : "${fester_s3_secret_key}" }
+      { "name" : "FESTER_S3_SECRET_KEY", "value" : "${fester_s3_secret_key}" },
+      { "name" : "IIIF_BASE_URL", "value" : "${fester_iiif_base_url}" }
     ]
   }
 ]

--- a/environments/test-iiif/variables.tf
+++ b/environments/test-iiif/variables.tf
@@ -2,6 +2,9 @@
 variable "region" { default = "us-west-2" }
 variable "aws_profile" { default = "default" }
 
+# Load Balancer Settings
+variable "lb_idle_timeout" { default = "300" }
+
 # Needed to reference remote state VPC networks
 variable "terraform_remote_hostname" {}
 variable "terraform_remote_token" {}
@@ -18,6 +21,7 @@ variable "fargate_ecs_task_execution_role_arn" { default = "arn:aws:iam::aws:pol
 
 # Flag to destroy src buckets
 variable "force_destroy_src_bucket" { default = "false" }
+variable "force_destroy_cache_bucket" { default = "false" }
 
 # Fargate IIIF Settings
 variable "container_host_memory" { default = "2048" }
@@ -53,6 +57,9 @@ variable "cantaloupe_s3_source_basiclookup_suffix" { default = ".jpx" }
 variable "cantaloupe_source_static" { default = "S3Source" }
 variable "cantaloupe_heapsize" { default = "2g" }
 variable "cantaloupe_healthcheck_path" { default = "/iiif/2" }
+variable "cantaloupe_cloudwatch_log_group" { default = "/ecs/test-iiif" }
+variable "cantaloupe_cloudwatch_region" { default = "us-west-2" }
+variable "cantaloupe_cloudwatch_stream_prefix" { default = "cantaloupe_" }
 
 # fester environment variables
 variable "fester_memory" { default = "1024" }
@@ -65,6 +72,10 @@ variable "fester_s3_bucket" { default = "" }
 variable "fester_s3_access_key" { default = "" }
 variable "fester_s3_secret_key" { default = "" }
 variable "fester_s3_region" { default = "" }
+variable "fester_iiif_base_url" { default = "https://test-iiif.library.ucla.edu/iiif/2" }
+variable "fester_cloudwatch_log_group" { default = "/ecs/test-iiif" }
+variable "fester_cloudwatch_region" { default = "us-west-2" }
+variable "fester_cloudwatch_stream_prefix" { default = "fester_" }
 
 ## KakaduConverter Variables
 variable kakadu_converter_s3_tiff_bucket {}


### PR DESCRIPTION
*Summary of changes*
* The following configuration changes have been made on test-iiif and prod-iiif
  * Renamed all manifeststore fields, targets, and resources to fester
  * Added awslogdriver into the Fargate definition to forward STDOUT logs to CloudWatch
  * Enabled Cantaloupe cache bucket and reconfigured DNS to point to the AWS ALB instead of AWS CloudFront
  * Adjust ALB to set connection timeout between ALB and backend from 60 seconds, to 300 seconds
  * Deployed fester:0.1.0 onto prod-iiif and stage-iiif
* stage-iiif is newly created in this PR