### PR TITLE
[IIIF-614] Creating a skeleton k8s manifest for Cantaloupe/Fester deployment

### DIFF
--- a/environments/test/eks-iam/main.tf
+++ b/environments/test/eks-iam/main.tf
@@ -20,7 +20,7 @@ data "aws_iam_policy_document" "eks_assume_policy_document" {
 }
 
 resource "aws_iam_role" "iam_for_eks" {
-  name = "terraform_eks_test-eks"
+  name = "test-eks"
   assume_role_policy = data.aws_iam_policy_document.eks_assume_policy_document.json
 } 
 
@@ -35,7 +35,7 @@ resource "aws_iam_role_policy_attachment" "eks_attach_cluster_policy" {
 }
 
 resource "aws_iam_role" "iam_for_eks_node_group" {
-  name = "terraform_nodegroup_test-eks"
+  name = "nodegroup_test-eks"
 
   assume_role_policy = jsonencode({
     Statement = [{
@@ -62,5 +62,15 @@ resource "aws_iam_role_policy_attachment" "iam_for_eks_node_group-AmazonEKS_CNI_
 resource "aws_iam_role_policy_attachment" "iam_for_eks_node_group-AmazonEC2ContainerRegistryReadOnly" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
   role       = aws_iam_role.iam_for_eks_node_group.name
+}
+
+resource "aws_iam_policy" "alb_ingress_policy" {
+  name = "Test-EKS-ALBIngressController"
+  policy = file("policies/ALBIngressController.json")
+}
+
+resource "aws_iam_role_policy_attachment" "iam_for_alb_ingress" {
+  policy_arn = aws_iam_policy.alb_ingress_policy.arn
+  role = aws_iam_role.iam_for_eks.name
 }
 

--- a/environments/test/eks-iam/main.tf
+++ b/environments/test/eks-iam/main.tf
@@ -64,13 +64,3 @@ resource "aws_iam_role_policy_attachment" "iam_for_eks_node_group-AmazonEC2Conta
   role       = aws_iam_role.iam_for_eks_node_group.name
 }
 
-resource "aws_iam_policy" "alb_ingress_policy" {
-  name = "Test-EKS-ALBIngressController"
-  policy = file("policies/ALBIngressController.json")
-}
-
-resource "aws_iam_role_policy_attachment" "iam_for_alb_ingress" {
-  policy_arn = aws_iam_policy.alb_ingress_policy.arn
-  role = aws_iam_role.iam_for_eks.name
-}
-

--- a/environments/test/eks-iam/policies/ALBIngressController.json
+++ b/environments/test/eks-iam/policies/ALBIngressController.json
@@ -1,0 +1,118 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "acm:DescribeCertificate",
+        "acm:ListCertificates",
+        "acm:GetCertificate"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:AuthorizeSecurityGroupIngress",
+        "ec2:CreateSecurityGroup",
+        "ec2:CreateTags",
+        "ec2:DeleteTags",
+        "ec2:DeleteSecurityGroup",
+        "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAddresses",
+        "ec2:DescribeInstances",
+        "ec2:DescribeInstanceStatus",
+        "ec2:DescribeInternetGateways",
+        "ec2:DescribeNetworkInterfaces",
+        "ec2:DescribeSecurityGroups",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeTags",
+        "ec2:DescribeVpcs",
+        "ec2:ModifyInstanceAttribute",
+        "ec2:ModifyNetworkInterfaceAttribute",
+        "ec2:RevokeSecurityGroupIngress"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:AddListenerCertificates",
+        "elasticloadbalancing:AddTags",
+        "elasticloadbalancing:CreateListener",
+        "elasticloadbalancing:CreateLoadBalancer",
+        "elasticloadbalancing:CreateRule",
+        "elasticloadbalancing:CreateTargetGroup",
+        "elasticloadbalancing:DeleteListener",
+        "elasticloadbalancing:DeleteLoadBalancer",
+        "elasticloadbalancing:DeleteRule",
+        "elasticloadbalancing:DeleteTargetGroup",
+        "elasticloadbalancing:DeregisterTargets",
+        "elasticloadbalancing:DescribeListenerCertificates",
+        "elasticloadbalancing:DescribeListeners",
+        "elasticloadbalancing:DescribeLoadBalancers",
+        "elasticloadbalancing:DescribeLoadBalancerAttributes",
+        "elasticloadbalancing:DescribeRules",
+        "elasticloadbalancing:DescribeSSLPolicies",
+        "elasticloadbalancing:DescribeTags",
+        "elasticloadbalancing:DescribeTargetGroups",
+        "elasticloadbalancing:DescribeTargetGroupAttributes",
+        "elasticloadbalancing:DescribeTargetHealth",
+        "elasticloadbalancing:ModifyListener",
+        "elasticloadbalancing:ModifyLoadBalancerAttributes",
+        "elasticloadbalancing:ModifyRule",
+        "elasticloadbalancing:ModifyTargetGroup",
+        "elasticloadbalancing:ModifyTargetGroupAttributes",
+        "elasticloadbalancing:RegisterTargets",
+        "elasticloadbalancing:RemoveListenerCertificates",
+        "elasticloadbalancing:RemoveTags",
+        "elasticloadbalancing:SetIpAddressType",
+        "elasticloadbalancing:SetSecurityGroups",
+        "elasticloadbalancing:SetSubnets",
+        "elasticloadbalancing:SetWebACL"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iam:CreateServiceLinkedRole",
+        "iam:GetServerCertificate",
+        "iam:ListServerCertificates"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "cognito-idp:DescribeUserPoolClient"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "waf-regional:GetWebACLForResource",
+        "waf-regional:GetWebACL",
+        "waf-regional:AssociateWebACL",
+        "waf-regional:DisassociateWebACL"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "tag:GetResources",
+        "tag:TagResources"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "waf:GetWebACL"
+      ],
+      "Resource": "*"
+    }
+  ]
+}

--- a/environments/test/eks-network/test.tfvars
+++ b/environments/test/eks-network/test.tfvars
@@ -1,12 +1,12 @@
 ### VPC Settings
 vpc_tag_map = {
   "Name" = "Test-EKS-Network"
-  "kubernetes.io/cluster/eks_cluster" = "shared"
+  "kubernetes.io/cluster/test-eks-cluster" = "shared"
 }
 
 k8s_subnet_tag_map = {
   "Name" = "Test-EKS-Network",
-  "kubernetes.io/cluster/eks_cluster" = "shared"
+  "kubernetes.io/cluster/test-eks-cluster" = "shared"
 }
 
 default_tag = "Test-EKS-Network"

--- a/environments/test/eks-network/test.tfvars
+++ b/environments/test/eks-network/test.tfvars
@@ -6,7 +6,8 @@ vpc_tag_map = {
 
 k8s_subnet_tag_map = {
   "Name" = "Test-EKS-Network",
-  "kubernetes.io/cluster/test-eks-cluster" = "shared"
+  "kubernetes.io/cluster/test-eks-cluster" = "shared",
+  "kubernetes.io/role/elb" = "1"
 }
 
 default_tag = "Test-EKS-Network"

--- a/environments/test/eks/helpers/oidc-thumbprint.sh
+++ b/environments/test/eks/helpers/oidc-thumbprint.sh
@@ -1,0 +1,5 @@
+### This will retrieve the last certificate from the output, obtain the fingerprint, and convert the fingerprint into a thumbprint format(lower case and no colons)
+#!/bin/bash
+THUMBPRINT=$(echo | openssl s_client -servername oidc.eks.${1}.amazonaws.com -showcerts -connect oidc.eks.${1}.amazonaws.com:443 2>&- | tac | sed -n '/-----END CERTIFICATE-----/,/-----BEGIN CERTIFICATE-----/p; /-----BEGIN CERTIFICATE-----/q' | tac | openssl x509 -fingerprint -noout | sed 's/://g' | awk -F= '{print tolower($2)}')
+THUMBPRINT_JSON="{\"thumbprint\": \"${THUMBPRINT}\"}"
+echo ${THUMBPRINT_JSON}

--- a/environments/test/eks/main.tf
+++ b/environments/test/eks/main.tf
@@ -36,7 +36,7 @@ provider "aws" {
 }
 
 resource "aws_eks_cluster" "eks_cluster" {
-  name = "eks_cluster"
+  name = "test-eks-cluster"
   role_arn = data.terraform_remote_state.iam.outputs.eks_role_arn
   
   vpc_config {

--- a/environments/test/eks/policies/ALBIngressController.json
+++ b/environments/test/eks/policies/ALBIngressController.json
@@ -1,0 +1,118 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "acm:DescribeCertificate",
+        "acm:ListCertificates",
+        "acm:GetCertificate"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:AuthorizeSecurityGroupIngress",
+        "ec2:CreateSecurityGroup",
+        "ec2:CreateTags",
+        "ec2:DeleteTags",
+        "ec2:DeleteSecurityGroup",
+        "ec2:DescribeAccountAttributes",
+        "ec2:DescribeAddresses",
+        "ec2:DescribeInstances",
+        "ec2:DescribeInstanceStatus",
+        "ec2:DescribeInternetGateways",
+        "ec2:DescribeNetworkInterfaces",
+        "ec2:DescribeSecurityGroups",
+        "ec2:DescribeSubnets",
+        "ec2:DescribeTags",
+        "ec2:DescribeVpcs",
+        "ec2:ModifyInstanceAttribute",
+        "ec2:ModifyNetworkInterfaceAttribute",
+        "ec2:RevokeSecurityGroupIngress"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:AddListenerCertificates",
+        "elasticloadbalancing:AddTags",
+        "elasticloadbalancing:CreateListener",
+        "elasticloadbalancing:CreateLoadBalancer",
+        "elasticloadbalancing:CreateRule",
+        "elasticloadbalancing:CreateTargetGroup",
+        "elasticloadbalancing:DeleteListener",
+        "elasticloadbalancing:DeleteLoadBalancer",
+        "elasticloadbalancing:DeleteRule",
+        "elasticloadbalancing:DeleteTargetGroup",
+        "elasticloadbalancing:DeregisterTargets",
+        "elasticloadbalancing:DescribeListenerCertificates",
+        "elasticloadbalancing:DescribeListeners",
+        "elasticloadbalancing:DescribeLoadBalancers",
+        "elasticloadbalancing:DescribeLoadBalancerAttributes",
+        "elasticloadbalancing:DescribeRules",
+        "elasticloadbalancing:DescribeSSLPolicies",
+        "elasticloadbalancing:DescribeTags",
+        "elasticloadbalancing:DescribeTargetGroups",
+        "elasticloadbalancing:DescribeTargetGroupAttributes",
+        "elasticloadbalancing:DescribeTargetHealth",
+        "elasticloadbalancing:ModifyListener",
+        "elasticloadbalancing:ModifyLoadBalancerAttributes",
+        "elasticloadbalancing:ModifyRule",
+        "elasticloadbalancing:ModifyTargetGroup",
+        "elasticloadbalancing:ModifyTargetGroupAttributes",
+        "elasticloadbalancing:RegisterTargets",
+        "elasticloadbalancing:RemoveListenerCertificates",
+        "elasticloadbalancing:RemoveTags",
+        "elasticloadbalancing:SetIpAddressType",
+        "elasticloadbalancing:SetSecurityGroups",
+        "elasticloadbalancing:SetSubnets",
+        "elasticloadbalancing:SetWebACL"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iam:CreateServiceLinkedRole",
+        "iam:GetServerCertificate",
+        "iam:ListServerCertificates"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "cognito-idp:DescribeUserPoolClient"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "waf-regional:GetWebACLForResource",
+        "waf-regional:GetWebACL",
+        "waf-regional:AssociateWebACL",
+        "waf-regional:DisassociateWebACL"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "tag:GetResources",
+        "tag:TagResources"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "waf:GetWebACL"
+      ],
+      "Resource": "*"
+    }
+  ]
+}

--- a/environments/test/eks/policies/oidc_assume_role_policy.json.template
+++ b/environments/test/eks/policies/oidc_assume_role_policy.json.template
@@ -1,0 +1,17 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "${OIDC_ARN}"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "${OIDC_URL}:sub": "system:serviceaccount:${NAMESPACE}:${SA_NAME}"
+        }
+      }
+    }
+  ]
+}

--- a/k8s/alb-config/alb-ingress-controller.yaml
+++ b/k8s/alb-config/alb-ingress-controller.yaml
@@ -1,0 +1,70 @@
+# Application Load Balancer (ALB) Ingress Controller Deployment Manifest.
+# This manifest details sensible defaults for deploying an ALB Ingress Controller.
+# GitHub: https://github.com/kubernetes-sigs/aws-alb-ingress-controller
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: alb-ingress-controller
+  name: alb-ingress-controller
+  # Namespace the ALB Ingress Controller should run in. Does not impact which
+  # namespaces it's able to resolve ingress resource for. For limiting ingress
+  # namespace scope, see --watch-namespace.
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: alb-ingress-controller
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: alb-ingress-controller
+    spec:
+      containers:
+        - name: alb-ingress-controller
+          args:
+            # Limit the namespace where this ALB Ingress Controller deployment will
+            # resolve ingress resources. If left commented, all namespaces are used.
+            # - --watch-namespace=your-k8s-namespace
+
+            # Setting the ingress-class flag below ensures that only ingress resources with the
+            # annotation kubernetes.io/ingress.class: "alb" are respected by the controller. You may
+            # choose any class you'd like for this controller to respect.
+            - --ingress-class=alb
+
+            # REQUIRED
+            # Name of your cluster. Used when naming resources created
+            # by the ALB Ingress Controller, providing distinction between
+            # clusters.
+            - --cluster-name=test-eks-cluster
+
+            # AWS VPC ID this ingress controller will use to create AWS resources.
+            # If unspecified, it will be discovered from ec2metadata.
+            # - --aws-vpc-id=vpc-08e01bc3c4128d95b
+
+            # AWS region this ingress controller will operate in.
+            # If unspecified, it will be discovered from ec2metadata.
+            # List of regions: http://docs.aws.amazon.com/general/latest/gr/rande.html#vpc_region
+            # - --aws-region=us-west-2
+
+            # Enables logging on all outbound requests sent to the AWS API.
+            # If logging is desired, set to true.
+            # - --aws-api-debug
+            # Maximum number of times to retry the aws calls.
+            # defaults to 10.
+            # - --aws-max-retries=10
+          # env:
+            # AWS key id for authenticating with the AWS API.
+            # This is only here for examples. It's recommended you instead use
+            # a project like kube2iam for granting access.
+            #- name: AWS_ACCESS_KEY_ID
+            #  value: KEYVALUE
+
+            # AWS key secret for authenticating with the AWS API.
+            # This is only here for examples. It's recommended you instead use
+            # a project like kube2iam for granting access.
+            #- name: AWS_SECRET_ACCESS_KEY
+            #  value: SECRETVALUE
+          # Repository location of the ALB Ingress Controller.
+          image: docker.io/amazon/aws-alb-ingress-controller:v1.1.4
+      serviceAccountName: alb-ingress-controller

--- a/k8s/alb-config/alb-ingress-role-account.yaml
+++ b/k8s/alb-config/alb-ingress-role-account.yaml
@@ -1,0 +1,62 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app.kubernetes.io/name: alb-ingress-controller
+  name: alb-ingress-controller
+rules:
+  - apiGroups:
+      - ""
+      - extensions
+    resources:
+      - configmaps
+      - endpoints
+      - events
+      - ingresses
+      - ingresses/status
+      - services
+    verbs:
+      - create
+      - get
+      - list
+      - update
+      - watch
+      - patch
+  - apiGroups:
+      - ""
+      - extensions
+    resources:
+      - nodes
+      - pods
+      - secrets
+      - services
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app.kubernetes.io/name: alb-ingress-controller
+  name: alb-ingress-controller
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: alb-ingress-controller
+subjects:
+  - kind: ServiceAccount
+    name: alb-ingress-controller
+    namespace: kube-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app.kubernetes.io/name: alb-ingress-controller
+  name: alb-ingress-controller
+  namespace: kube-system
+...

--- a/k8s/alb-config/sa_alb_ingress.yaml
+++ b/k8s/alb-config/sa_alb_ingress.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: alb-ingress-controller
+  namespace: kube-system
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::053298376377:role/TestALBIngressRole

--- a/k8s/test-iiif/cantaloupe-deployment.yaml
+++ b/k8s/test-iiif/cantaloupe-deployment.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: "cantaloupe-deployment"
+  namespace: "test-iiif"
+spec:
+  selector:
+    matchLabels:
+      app: "cantaloupe"
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: "cantaloupe"
+    spec:
+      containers:
+      - name: cantaloupe
+        image: uclalibrary/cantaloupe-ucla:4.1.4
+        ports:
+        - containerPort: 8182
+      imagePullSecrets:
+      - name: services-dockerhub-creds

--- a/k8s/test-iiif/cantaloupe-ingress.yaml
+++ b/k8s/test-iiif/cantaloupe-ingress.yaml
@@ -1,0 +1,18 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: "cantaloupe-ingress"
+  namespace: "test-iiif"
+  annotations:
+    kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/scheme: internet-facing
+  labels:
+    app: cantaloupe-ingress
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /*
+            backend:
+              serviceName: "cantaloupe-service"
+              servicePort: 8182

--- a/k8s/test-iiif/cantaloupe-service.yaml
+++ b/k8s/test-iiif/cantaloupe-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "cantaloupe-service"
+  namespace: "test-iiif"
+spec:
+  ports:
+    - port: 8182
+      targetPort: 8182
+      protocol: TCP
+  type: NodePort
+  selector:
+    app: "cantaloupe"

--- a/k8s/test-iiif/cantaloupe.yaml
+++ b/k8s/test-iiif/cantaloupe.yaml
@@ -1,0 +1,22 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cantaloupe
+  namespace: "test-iiif"  
+spec:
+  selector:
+    matchLabels:
+      app: cantaloupe
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: cantaloupe
+    spec:
+      containers:
+      - name: cantaloupe
+        image: uclalibrary/cantaloupe-ucla:4.1.4
+        ports:
+        - containerPort: 8182
+      imagePullSecrets:
+      - name: services-dockerhub-creds

--- a/k8s/test-iiif/namespace.yaml
+++ b/k8s/test-iiif/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "test-iiif"


### PR DESCRIPTION
*Summary of changes*
* k8s is configured to use openconnect as an identity provider. This allows k8s service accounts to assume AWS IAM roles with attached policies. The benefit of this is that we do not have to manage AWS Access Key pairs if the given service supports it
* ALB Ingress is configured. This is not configured by default in EKS and requires orchestration through Terraform and Kubectl to set up
* There is a skeleton cantaloupe manifest file to deploy the container in k8s within this repo. I've separated it out to 4 components(ingress, deployment, service, namespace)

I'll create a follow-up ticket to document all these moving parts in Confluence as part of our infrastructure documentation.