### PR TITLE
[IIIF-740] Remove HTTPS redirect

### DIFF
--- a/environments/prod-iiif/main.tf
+++ b/environments/prod-iiif/main.tf
@@ -205,17 +205,104 @@ resource "aws_lb_listener" "iiif_http_listener" {
   protocol          = "HTTP"
 
   default_action {
-    type             = "redirect"
-
-    redirect {
-      port = "443"
-      protocol = "HTTPS"
-      status_code = "HTTP_301"    
-    }
+    target_group_arn = "${aws_lb_target_group.cantaloupe_tg.arn}"
+    type             = "forward"
   }
 
   depends_on = ["module.alb"]
 }
+
+resource "aws_lb_listener_rule" "http_fester_docs_root" {
+  listener_arn = "${aws_lb_listener.iiif_http_listener.arn}"
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.fester_tg.arn}"
+  }
+
+  condition {
+    path_pattern {
+      values = ["/docs/fester"]
+    }
+  }
+}
+
+resource "aws_lb_listener_rule" "http_fester_docs_subpath" {
+  listener_arn = "${aws_lb_listener.iiif_http_listener.arn}"
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.fester_tg.arn}"
+  }
+
+  condition {
+    path_pattern {
+      values = ["/docs/fester/*"]
+    }
+  }
+}
+
+resource "aws_lb_listener_rule" "http_fester_healthcheck" {
+  listener_arn = "${aws_lb_listener.iiif_http_listener.arn}"
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.fester_tg.arn}"
+  }
+
+  condition {
+    path_pattern {
+      values = ["/status/fester"]
+    }
+  }
+}
+
+resource "aws_lb_listener_rule" "http_fester_collections_root" {
+  listener_arn = "${aws_lb_listener.iiif_http_listener.arn}"
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.fester_tg.arn}"
+  }
+
+  condition {
+    path_pattern {
+      values = ["/collections"]
+    }
+  }
+}
+
+resource "aws_lb_listener_rule" "http_fester_collections_subpath" {
+  listener_arn = "${aws_lb_listener.iiif_http_listener.arn}"
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.fester_tg.arn}"
+  }
+
+  condition {
+    path_pattern {
+      values = ["/collections/*"]
+    }
+  }
+}
+
+resource "aws_lb_listener_rule" "http_fester_manifest" {
+  listener_arn = "${aws_lb_listener.iiif_http_listener.arn}"
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.fester_tg.arn}"
+  }
+
+  condition {
+    path_pattern {
+      values = ["/*/manifest"]
+    }
+  }
+}
+
+
 
 ### Create a listener to answer on HTTPS and set the default route to Cantaloupe's target group
 resource "aws_lb_listener" "iiif_https_listener" {
@@ -233,7 +320,7 @@ resource "aws_lb_listener" "iiif_https_listener" {
   depends_on = ["module.alb"]
 }
 
-resource "aws_lb_listener_rule" "fester_docs_root" {
+resource "aws_lb_listener_rule" "https_fester_docs_root" {
   listener_arn = "${aws_lb_listener.iiif_https_listener.arn}"
 
   action {
@@ -248,7 +335,7 @@ resource "aws_lb_listener_rule" "fester_docs_root" {
   }
 }
 
-resource "aws_lb_listener_rule" "fester_docs_subpath" {
+resource "aws_lb_listener_rule" "https_fester_docs_subpath" {
   listener_arn = "${aws_lb_listener.iiif_https_listener.arn}"
 
   action {
@@ -263,7 +350,7 @@ resource "aws_lb_listener_rule" "fester_docs_subpath" {
   }
 }
 
-resource "aws_lb_listener_rule" "fester_healthcheck" {
+resource "aws_lb_listener_rule" "https_fester_healthcheck" {
   listener_arn = "${aws_lb_listener.iiif_https_listener.arn}"
 
   action {
@@ -278,7 +365,7 @@ resource "aws_lb_listener_rule" "fester_healthcheck" {
   }
 }
 
-resource "aws_lb_listener_rule" "fester_collections_root" {
+resource "aws_lb_listener_rule" "https_fester_collections_root" {
   listener_arn = "${aws_lb_listener.iiif_https_listener.arn}"
 
   action {
@@ -293,7 +380,7 @@ resource "aws_lb_listener_rule" "fester_collections_root" {
   }
 }
 
-resource "aws_lb_listener_rule" "fester_collections_subpath" {
+resource "aws_lb_listener_rule" "https_fester_collections_subpath" {
   listener_arn = "${aws_lb_listener.iiif_https_listener.arn}"
 
   action {
@@ -308,7 +395,7 @@ resource "aws_lb_listener_rule" "fester_collections_subpath" {
   }
 }
 
-resource "aws_lb_listener_rule" "fester_manifest" {
+resource "aws_lb_listener_rule" "https_fester_manifest" {
   listener_arn = "${aws_lb_listener.iiif_https_listener.arn}"
 
   action {

--- a/environments/stage-iiif/main.tf
+++ b/environments/stage-iiif/main.tf
@@ -189,17 +189,104 @@ resource "aws_lb_listener" "iiif_http_listener" {
   protocol          = "HTTP"
 
   default_action {
-    type             = "redirect"
-
-    redirect {
-      port = "443"
-      protocol = "HTTPS"
-      status_code = "HTTP_301"    
-    }
+    target_group_arn = "${aws_lb_target_group.cantaloupe_tg.arn}"
+    type             = "forward"
   }
 
   depends_on = ["module.alb"]
 }
+
+resource "aws_lb_listener_rule" "http_fester_docs_root" {
+  listener_arn = "${aws_lb_listener.iiif_http_listener.arn}"
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.fester_tg.arn}"
+  }
+
+  condition {
+    path_pattern {
+      values = ["/docs/fester"]
+    }
+  }
+}
+
+resource "aws_lb_listener_rule" "http_fester_docs_subpath" {
+  listener_arn = "${aws_lb_listener.iiif_http_listener.arn}"
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.fester_tg.arn}"
+  }
+
+  condition {
+    path_pattern {
+      values = ["/docs/fester/*"]
+    }
+  }
+}
+
+resource "aws_lb_listener_rule" "http_fester_healthcheck" {
+  listener_arn = "${aws_lb_listener.iiif_http_listener.arn}"
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.fester_tg.arn}"
+  }
+
+  condition {
+    path_pattern {
+      values = ["/status/fester"]
+    }
+  }
+}
+
+resource "aws_lb_listener_rule" "http_fester_collections_root" {
+  listener_arn = "${aws_lb_listener.iiif_http_listener.arn}"
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.fester_tg.arn}"
+  }
+
+  condition {
+    path_pattern {
+      values = ["/collections"]
+    }
+  }
+}
+
+resource "aws_lb_listener_rule" "http_fester_collections_subpath" {
+  listener_arn = "${aws_lb_listener.iiif_http_listener.arn}"
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.fester_tg.arn}"
+  }
+
+  condition {
+    path_pattern {
+      values = ["/collections/*"]
+    }
+  }
+}
+
+resource "aws_lb_listener_rule" "http_fester_manifest" {
+  listener_arn = "${aws_lb_listener.iiif_http_listener.arn}"
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.fester_tg.arn}"
+  }
+
+  condition {
+    path_pattern {
+      values = ["/*/manifest"]
+    }
+  }
+}
+
+
 
 ### Create a listener to answer on HTTPS and set the default route to Cantaloupe's target group
 resource "aws_lb_listener" "iiif_https_listener" {
@@ -217,7 +304,7 @@ resource "aws_lb_listener" "iiif_https_listener" {
   depends_on = ["module.alb"]
 }
 
-resource "aws_lb_listener_rule" "fester_docs_root" {
+resource "aws_lb_listener_rule" "https_fester_docs_root" {
   listener_arn = "${aws_lb_listener.iiif_https_listener.arn}"
 
   action {
@@ -232,7 +319,7 @@ resource "aws_lb_listener_rule" "fester_docs_root" {
   }
 }
 
-resource "aws_lb_listener_rule" "fester_docs_subpath" {
+resource "aws_lb_listener_rule" "https_fester_docs_subpath" {
   listener_arn = "${aws_lb_listener.iiif_https_listener.arn}"
 
   action {
@@ -247,7 +334,7 @@ resource "aws_lb_listener_rule" "fester_docs_subpath" {
   }
 }
 
-resource "aws_lb_listener_rule" "fester_healthcheck" {
+resource "aws_lb_listener_rule" "https_fester_healthcheck" {
   listener_arn = "${aws_lb_listener.iiif_https_listener.arn}"
 
   action {
@@ -262,7 +349,7 @@ resource "aws_lb_listener_rule" "fester_healthcheck" {
   }
 }
 
-resource "aws_lb_listener_rule" "fester_collections_root" {
+resource "aws_lb_listener_rule" "https_fester_collections_root" {
   listener_arn = "${aws_lb_listener.iiif_https_listener.arn}"
 
   action {
@@ -277,7 +364,7 @@ resource "aws_lb_listener_rule" "fester_collections_root" {
   }
 }
 
-resource "aws_lb_listener_rule" "fester_collections_subpath" {
+resource "aws_lb_listener_rule" "https_fester_collections_subpath" {
   listener_arn = "${aws_lb_listener.iiif_https_listener.arn}"
 
   action {
@@ -292,7 +379,7 @@ resource "aws_lb_listener_rule" "fester_collections_subpath" {
   }
 }
 
-resource "aws_lb_listener_rule" "fester_manifest" {
+resource "aws_lb_listener_rule" "https_fester_manifest" {
   listener_arn = "${aws_lb_listener.iiif_https_listener.arn}"
 
   action {

--- a/environments/test-iiif/main.tf
+++ b/environments/test-iiif/main.tf
@@ -199,17 +199,104 @@ resource "aws_lb_listener" "iiif_http_listener" {
   protocol          = "HTTP"
 
   default_action {
-    type             = "redirect"
-
-    redirect {
-      port = "443"
-      protocol = "HTTPS"
-      status_code = "HTTP_301"    
-    }
+    target_group_arn = "${aws_lb_target_group.cantaloupe_tg.arn}"
+    type             = "forward"
   }
 
   depends_on = ["module.alb"]
 }
+
+resource "aws_lb_listener_rule" "http_fester_docs_root" {
+  listener_arn = "${aws_lb_listener.iiif_http_listener.arn}"
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.fester_tg.arn}"
+  }
+
+  condition {
+    path_pattern {
+      values = ["/docs/fester"]
+    }
+  }
+}
+
+resource "aws_lb_listener_rule" "http_fester_docs_subpath" {
+  listener_arn = "${aws_lb_listener.iiif_http_listener.arn}"
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.fester_tg.arn}"
+  }
+
+  condition {
+    path_pattern {
+      values = ["/docs/fester/*"]
+    }
+  }
+}
+
+
+resource "aws_lb_listener_rule" "fester_fester_healthcheck" {
+  listener_arn = "${aws_lb_listener.iiif_http_listener.arn}"
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.fester_tg.arn}"
+  }
+
+  condition {
+    path_pattern {
+      values = ["/status/fester"]
+    }
+  }
+}
+
+resource "aws_lb_listener_rule" "http_fester_collections_root" {
+  listener_arn = "${aws_lb_listener.iiif_http_listener.arn}"
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.fester_tg.arn}"
+  }
+
+  condition {
+    path_pattern {
+      values = ["/collections"]
+    }
+  }
+}
+
+resource "aws_lb_listener_rule" "http_fester_collections_subpath" {
+  listener_arn = "${aws_lb_listener.iiif_http_listener.arn}"
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.fester_tg.arn}"
+  }
+
+  condition {
+    path_pattern {
+      values = ["/collections/*"]
+    }
+  }
+}
+
+resource "aws_lb_listener_rule" "http_fester_manifest" {
+  listener_arn = "${aws_lb_listener.iiif_http_listener.arn}"
+
+  action {
+    type             = "forward"
+    target_group_arn = "${aws_lb_target_group.fester_tg.arn}"
+  }
+
+  condition {
+    path_pattern {
+      values = ["/*/manifest"]
+    }
+  }
+}
+
 
 ### Create a listener to answer on HTTPS and set the default route to Cantaloupe's target group
 resource "aws_lb_listener" "iiif_https_listener" {
@@ -242,7 +329,7 @@ resource "aws_lb_listener_rule" "fester_docs_root" {
   }
 }
 
-resource "aws_lb_listener_rule" "fester_docs_subpath" {
+resource "aws_lb_listener_rule" "https_fester_docs_subpath" {
   listener_arn = "${aws_lb_listener.iiif_https_listener.arn}"
 
   action {
@@ -258,7 +345,7 @@ resource "aws_lb_listener_rule" "fester_docs_subpath" {
 }
 
 
-resource "aws_lb_listener_rule" "fester_healthcheck" {
+resource "aws_lb_listener_rule" "https_fester_healthcheck" {
   listener_arn = "${aws_lb_listener.iiif_https_listener.arn}"
 
   action {
@@ -273,7 +360,7 @@ resource "aws_lb_listener_rule" "fester_healthcheck" {
   }
 }
 
-resource "aws_lb_listener_rule" "fester_collections_root" {
+resource "aws_lb_listener_rule" "https_fester_collections_root" {
   listener_arn = "${aws_lb_listener.iiif_https_listener.arn}"
 
   action {
@@ -288,7 +375,7 @@ resource "aws_lb_listener_rule" "fester_collections_root" {
   }
 }
 
-resource "aws_lb_listener_rule" "fester_collections_subpath" {
+resource "aws_lb_listener_rule" "https_fester_collections_subpath" {
   listener_arn = "${aws_lb_listener.iiif_https_listener.arn}"
 
   action {
@@ -303,7 +390,7 @@ resource "aws_lb_listener_rule" "fester_collections_subpath" {
   }
 }
 
-resource "aws_lb_listener_rule" "fester_manifest" {
+resource "aws_lb_listener_rule" "https_fester_manifest" {
   listener_arn = "${aws_lb_listener.iiif_https_listener.arn}"
 
   action {


### PR DESCRIPTION
By default, CORS headers are added to AWS Load Balancers. Although it doesn't look like AWS Load Balancers have an option to add cors headers to 301 actions.

I went ahead and removed the HTTPS redirect. We're still answering on HTTP and HTTPS.